### PR TITLE
Change order of object combination

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -198,12 +198,12 @@
      * @return {hash}
      */
     _getHitsSearchParams: function() {
-      return extend({}, this.searchParams, {
+      return extend({}, {
         hitsPerPage: this.options.hitsPerPage,
         page: this.page,
         facets: this.options.facets,
         facetFilters: this._getFacetFilters()
-      });
+      }, this.searchParams);
     },
 
     /**


### PR DESCRIPTION
This seems to make more sense when changing things like number of hits
returned on subsequent "search" calls after the first init.

Let me know if this breaks an intended logic, but it seems to me that if
I explicitly supply settings to a search then they should be used over
the defaults or init variables.
