### PR TITLE
Delete update.json

### DIFF
--- a/update.json
+++ b/update.json
@@ -1,8 +1,0 @@
-{
-  "packageManager": "bower",
-  "name": "algoliasearch",
-  "files": {
-    "basePath": "dist/",
-    "include": ["algoliasearch.js", "algoliasearch.min.js"]
-  }
-}


### PR DESCRIPTION
Update.json lives on the jsDelivr project. No need to included it here https://github.com/jsdelivr/jsdelivr/blob/master/files/algoliasearch/update.json

Reference: https://github.com/jsdelivr/jsdelivr/pull/1788
https://github.com/jsdelivr/libgrabber#add-updatejson-schema
