### PR TITLE
fix(_makeAngularRequestByHost): $http cache false

### DIFF
--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -645,6 +645,7 @@ AlgoliaSearch.prototype = {
             method: opts.method,
             data: body,
             headers: headers,
+            cache: false,
             timeout: this.requestTimeoutInMs
         }).then(function(response) {
             opts.callback(false, true, null, response.data);


### PR DESCRIPTION
Allow `_jsonRequest` to handle caching of requests rather than both
https://ng-click.com/$http#caching
