### PR TITLE
feat(x-algolia-agent): specify x-algolia-agent at search time

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -168,6 +168,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
   var requestDebug = require('debug')('algoliasearch:' + initialOpts.url);
 
   var body;
+  var additionalUA = initialOpts.additionalUA || '';
   var cache = initialOpts.cache;
   var client = this;
   var tries = 0;
@@ -182,9 +183,9 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     initialOpts.body.requests !== undefined) // client.search()
   ) {
     initialOpts.body.apiKey = this.apiKey;
-    headers = this._computeRequestHeaders(false);
+    headers = this._computeRequestHeaders(additionalUA, false);
   } else {
-    headers = this._computeRequestHeaders();
+    headers = this._computeRequestHeaders(additionalUA);
   }
 
   if (initialOpts.body !== undefined) {
@@ -241,7 +242,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         reqOpts.body = safeJSONStringify(reqOpts.jsonBody);
       }
       // re-compute headers, they could be omitting the API KEY
-      headers = client._computeRequestHeaders();
+      headers = client._computeRequestHeaders(additionalUA);
 
       reqOpts.timeouts = client._getTimeoutsForRequest(initialOpts.hostType);
       client._setHostIndexByType(0, initialOpts.hostType);
@@ -440,6 +441,9 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
 
 /*
 * Transform search param object in query string
+* @param {object} args arguments to add to the current query string
+* @param {string} params current query string
+* @return {string} the final query string
 */
 AlgoliaSearchCore.prototype._getSearchParams = function(args, params) {
   if (args === undefined || args === null) {
@@ -454,11 +458,15 @@ AlgoliaSearchCore.prototype._getSearchParams = function(args, params) {
   return params;
 };
 
-AlgoliaSearchCore.prototype._computeRequestHeaders = function(withAPIKey) {
+AlgoliaSearchCore.prototype._computeRequestHeaders = function(additionalUA, withAPIKey) {
   var forEach = require('foreach');
 
+  var ua = additionalUA ?
+    this._ua + ';' + additionalUA :
+    this._ua;
+
   var requestHeaders = {
-    'x-algolia-agent': this._ua,
+    'x-algolia-agent': ua,
     'x-algolia-application-id': this.applicationID
   };
 

--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -29,8 +29,8 @@ IndexCore.prototype.clearCache = function() {
 * Search inside the index using XMLHttpRequest request (Using a POST query to
 * minimize number of OPTIONS queries: Cross-Origin Resource Sharing).
 *
-* @param query the full text query
-* @param args (optional) if set, contains an object with query parameters:
+* @param {string} [query] the full text query
+* @param {object} [args] (optional) if set, contains an object with query parameters:
 * - page: (integer) Pagination parameter used to select the page to retrieve.
 *                   Page is zero-based and defaults to 0. Thus,
 *                   to retrieve the 10th page you need to set page=9
@@ -116,7 +116,7 @@ IndexCore.prototype.clearCache = function() {
 * - restrictSearchableAttributes: List of attributes you want to use for
 * textual search (must be a subset of the attributesToIndex index setting)
 * either comma separated or as an array
-* @param callback the result callback called with two arguments:
+* @param {function} [callback] the result callback called with two arguments:
 *  error: null or Error('message'). If false, the content contains the error.
 *  content: the server answer that contains the list of results.
 */
@@ -127,8 +127,8 @@ IndexCore.prototype.search = buildSearchMethod('query');
 * Search a record similar to the query inside the index using XMLHttpRequest request (Using a POST query to
 * minimize number of OPTIONS queries: Cross-Origin Resource Sharing).
 *
-* @param query the similar query
-* @param args (optional) if set, contains an object with query parameters.
+* @param {string} [query] the similar query
+* @param {object} [args] (optional) if set, contains an object with query parameters.
 *   All search parameters are supported (see search function), restrictSearchableAttributes and facetFilters
 *   are the two most useful to restrict the similar results and get more relevant content
 */
@@ -276,7 +276,7 @@ IndexCore.prototype.searchFacet = deprecate(function(params, callback) {
   'index.searchForFacetValues(params[, callback])'
 ));
 
-IndexCore.prototype._search = function(params, url, callback) {
+IndexCore.prototype._search = function(params, url, callback, additionalUA) {
   return this.as._jsonRequest({
     cache: this.cache,
     method: 'POST',
@@ -288,7 +288,8 @@ IndexCore.prototype._search = function(params, url, callback) {
       url: '/1/indexes/' + encodeURIComponent(this.indexName),
       body: {params: params}
     },
-    callback: callback
+    callback: callback,
+    additionalUA: additionalUA
   });
 };
 

--- a/src/buildSearchMethod.js
+++ b/src/buildSearchMethod.js
@@ -1,6 +1,5 @@
 module.exports = buildSearchMethod;
 
-var clone = require('./clone.js');
 var errors = require('./errors.js');
 
 /**

--- a/src/buildSearchMethod.js
+++ b/src/buildSearchMethod.js
@@ -1,8 +1,22 @@
 module.exports = buildSearchMethod;
 
+var clone = require('./clone.js');
 var errors = require('./errors.js');
 
+/**
+ * Creates a search method to be used in clients
+ * @param {string} queryParam the name of the attribute used for the query
+ * @param {string} url the url
+ * @return {function} the search method
+ */
 function buildSearchMethod(queryParam, url) {
+  /**
+   * The search method. Prepares the data and send the query to Algolia.
+   * @param {string} query the string used for query search
+   * @param {object} args additional parameters to send with the search
+   * @param {function} [callback] the callback to be called with the client gets the answer
+   * @return {undefined|Promise} If the callback is not provided then this methods returns a Promise
+   */
   return function search(query, args, callback) {
     // warn V2 users on how to search
     if (typeof query === 'function' && typeof args === 'object' ||
@@ -12,17 +26,19 @@ function buildSearchMethod(queryParam, url) {
       throw new errors.AlgoliaSearchError('index.search usage is index.search(query, params, cb)');
     }
 
+    // Normalizing the function signature
     if (arguments.length === 0 || typeof query === 'function') {
-      // .search(), .search(cb)
+      // Usage : .search(), .search(cb)
       callback = query;
       query = '';
     } else if (arguments.length === 1 || typeof args === 'function') {
-      // .search(query/args), .search(query, cb)
+      // Usage : .search(query/args), .search(query, cb)
       callback = args;
       args = undefined;
     }
+    // At this point we have 3 arguments with values
 
-    // .search(args), careful: typeof null === 'object'
+    // Usage : .search(args) // careful: typeof null === 'object'
     if (typeof query === 'object' && query !== null) {
       args = query;
       query = undefined;
@@ -36,11 +52,17 @@ function buildSearchMethod(queryParam, url) {
       params += queryParam + '=' + encodeURIComponent(query);
     }
 
+    var additionalUA;
     if (args !== undefined) {
+      if (args['x-algolia-agent']) {
+        additionalUA = args['x-algolia-agent'];
+        delete args['x-algolia-agent'];
+      }
       // `_getSearchParams` will augment params, do not be fooled by the = versus += from previous if
       params = this.as._getSearchParams(args, params);
     }
 
-    return this._search(params, url, callback);
+
+    return this._search(params, url, callback, additionalUA);
   };
 }

--- a/src/server/builds/AlgoliaSearchServer.js
+++ b/src/server/builds/AlgoliaSearchServer.js
@@ -59,8 +59,8 @@ AlgoliaSearchServer.prototype.disableSecuredAPIKey = function() {
   this._secure = null;
 };
 
-AlgoliaSearchServer.prototype._computeRequestHeaders = function() {
-  var headers = AlgoliaSearchServer.super_.prototype._computeRequestHeaders.call(this);
+AlgoliaSearchServer.prototype._computeRequestHeaders = function(additionalUA) {
+  var headers = AlgoliaSearchServer.super_.prototype._computeRequestHeaders.call(this, additionalUA);
 
   if (this._forward) {
     headers['x-algolia-api-key'] = this._forward.adminAPIKey;

--- a/test/spec/common/client/addAlgoliaAgent.js
+++ b/test/spec/common/client/addAlgoliaAgent.js
@@ -2,7 +2,7 @@
 
 var test = require('tape');
 
-test('client.addAlgoliaAgent(algoliaAgent)', function(t) {
+test('AddAlgoliaAgent and custom search-time agent with x-algolia-agent', function(t) {
   t.plan(1);
 
   var fauxJax = require('faux-jax');
@@ -20,9 +20,11 @@ test('client.addAlgoliaAgent(algoliaAgent)', function(t) {
   // Ensure we de-duplicate by re-adding the same agent a second time.
   client.addAlgoliaAgent('And some other incredible agent');
 
-  index.search('algolia agent');
+  index.search('algolia agent', {
+    'x-algolia-agent': 'the other agent'
+  });
 
-  var expectedAgent = fixture.algoliasearch.ua + ';And some other incredible agent';
+  var expectedAgent = fixture.algoliasearch.ua + ';And some other incredible agent;the other agent';
 
   fauxJax.once('request', function(req) {
     var agent = process.browser ?

--- a/test/utils/test-method-call.js
+++ b/test/utils/test-method-call.js
@@ -30,10 +30,9 @@ function testMethodCall(opts) {
 
   object[opts.methodName].apply(object, testCase.callArguments);
 
-  fauxJax.once('request', function(req) {
+  fauxJax.once('request', function(actualRequest) {
     fauxJax.restore();
 
-    var actualRequest = req;
     var expectedRequest = testCase.expectedRequest;
 
     actualRequest.respond(


### PR DESCRIPTION
**Summary**

Currently there is no way to specify an algolia agent at search time. The parameter `x-algolia-agent` is just ignored.

**Result**

This PR let the user specify a new Algolia agent the parameter `x-algolia-agent` (like with the REST API) and it will be appended to the ones specified with `addAlgoliaAgent`.

Fixes #493 