### PR TITLE
fix(algolia agent): Fix parameter name for algolia agent

### DIFF
--- a/src/buildSearchMethod.js
+++ b/src/buildSearchMethod.js
@@ -53,9 +53,9 @@ function buildSearchMethod(queryParam, url) {
 
     var additionalUA;
     if (args !== undefined) {
-      if (args['x-algolia-agent']) {
-        additionalUA = args['x-algolia-agent'];
-        delete args['x-algolia-agent'];
+      if (args.additionalUA) {
+        additionalUA = args.additionalUA;
+        delete args.additionalUA;
       }
       // `_getSearchParams` will augment params, do not be fooled by the = versus += from previous if
       params = this.as._getSearchParams(args, params);

--- a/test/spec/common/client/addAlgoliaAgent.js
+++ b/test/spec/common/client/addAlgoliaAgent.js
@@ -21,7 +21,7 @@ test('AddAlgoliaAgent and custom search-time agent with x-algolia-agent', functi
   client.addAlgoliaAgent('And some other incredible agent');
 
   index.search('algolia agent', {
-    'x-algolia-agent': 'the other agent'
+    additionalUA: 'the other agent'
   });
 
   var expectedAgent = fixture.algoliasearch.ua + ';And some other incredible agent;the other agent';


### PR DESCRIPTION
**Summary**

The algolia agent can be set with x-algolia-agent in the parameters used with the search method. However additionalUA is more explicit.

**Result**

```js
index.search('search it', {addtionalUA: 'super search agent'});
```

This adds a `super search agent` to the `x-algolia-agent` header.