### PR TITLE
chore(package) add files property

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "plugins",
     "index.js",
     "lite.js",
-    "reactnative.js"
+    "reactnative.js",
+    "bower.json"
   ],
   "dependencies": {
     "agentkeepalive": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
       "url": "http://www.algolia.com"
     }
   ],
+  "files": [
+    "src",
+    "dist",
+    "plugins",
+    "index.js",
+    "lite.js",
+    "reactnative.js"
+  ],
   "dependencies": {
     "agentkeepalive": "^2.1.1",
     "debug": "2.3.3",


### PR DESCRIPTION
the npm registry (and yarn, unpkg etc) use the files field to make sure that only files which are relevant to the reuser are in the package.

see <https://docs.npmjs.com/files/package.json#files>

fixes #527
