### PR TITLE
Check if 'process' exists prior to using it in browser build

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -10,7 +10,7 @@ var store = require('./store.js');
 // proxies limit)
 var MAX_API_KEY_LENGTH = 500;
 var RESET_APP_DATA_TIMER =
-  process.env.RESET_APP_DATA_TIMER && parseInt(process.env.RESET_APP_DATA_TIMER, 10) ||
+  typeof process !== 'undefined' && process.env.RESET_APP_DATA_TIMER && parseInt(process.env.RESET_APP_DATA_TIMER, 10) ||
   60 * 2 * 1000; // after 2 minutes reset to first host
 
 /*

--- a/src/browser/createAlgoliasearch.js
+++ b/src/browser/createAlgoliasearch.js
@@ -14,7 +14,7 @@ module.exports = function createAlgoliasearch(AlgoliaSearch, uaSuffix) {
   var places = require('../places.js');
   uaSuffix = uaSuffix || '';
 
-  if (process.env.NODE_ENV === 'debug') {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'debug') {
     require('debug').enable('algoliasearch*');
   }
 


### PR DESCRIPTION
This pull request will make sure the `process` variable is set prior to using it.

This is currently not an issue regarding the existing browser builds because `envify` will take care if initializing the `process` variable.

That being said, if some user wants to bundle the client in UMD format for example, then he will need to specify the following in his build:

```js
// Rollup example
replace({
      'process.env.NODE_ENV': JSON.stringify('production'),
      'process.env.RESET_APP_DATA_TIMER': 120000,
    }),
```

Unless this is indeed the expected behaviour, this PR solves the issue.

I'm wondering about the `NODE_ENV` though. Maybe we do want the users to override it that way, it is kinda common. With this PR, we can not simply "replace" it because we first check the `process`.

Happy to have your feedback on this.
