### PR TITLE
chore(pkg): list homepage on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "realtime",
     "autocomplete"
   ],
-  "homepage": "https://github.com/algolia/algoliasearch-client-js",
+  "homepage": "https://www.algolia.com/doc/api-client/javascript/",
   "bugs": "https://github.com/algolia/algoliasearch-client-js/issues",
   "author": {
     "name": "Algolia SAS",


### PR DESCRIPTION
**Summary**

The homepage now is the GitHub repo, which is already visible by clicking the link to the `repository` field. The website offers a cleaner start than the repository.

Another factor: on Yarnpkg.com, the `homepage` is being left out, because it's the same as the repository

**Result**

The linked `homepage` is now the getting started link of the Algolia documentation.