### PR TITLE
Use Array.isArray directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "foreach": "^2.0.5",
     "global": "^4.3.0",
     "inherits": "^2.0.1",
-    "isarray": "^2.0.1",
     "load-script": "^1.0.0",
     "object-keys": "^1.0.11",
     "querystring-es3": "^0.2.1",

--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -266,10 +266,9 @@ AlgoliaSearch.prototype.addUserKey = deprecate(function(acls, params, callback) 
  * @see {@link https://www.algolia.com/doc/rest_api#AddKey|Algolia REST API Documentation}
  */
 AlgoliaSearch.prototype.addApiKey = function(acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.addApiKey(arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -357,10 +356,9 @@ AlgoliaSearch.prototype.updateUserKey = deprecate(function(key, acls, params, ca
  * @see {@link https://www.algolia.com/doc/rest_api#UpdateIndexKey|Algolia REST API Documentation}
  */
 AlgoliaSearch.prototype.updateApiKey = function(key, acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.updateApiKey(key, arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -458,10 +456,9 @@ AlgoliaSearch.prototype.sendQueriesBatch = deprecate(function sendQueriesBatchDe
  * }], cb)
  */
 AlgoliaSearch.prototype.batch = function(operations, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.batch(operations[, callback])';
 
-  if (!isArray(operations)) {
+  if (!Array.isArray(operations)) {
     throw new Error(usage);
   }
 

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -42,7 +42,6 @@ function AlgoliaSearchCore(applicationID, apiKey, opts) {
   var debug = require('debug')('algoliasearch');
 
   var clone = require('./clone.js');
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: algoliasearch(applicationID, apiKey, opts)';
@@ -97,7 +96,7 @@ function AlgoliaSearchCore(applicationID, apiKey, opts) {
     // no hosts given, compute defaults
     this.hosts.read = [this.applicationID + '-dsn.algolia.net'].concat(defaultHosts);
     this.hosts.write = [this.applicationID + '.algolia.net'].concat(defaultHosts);
-  } else if (isArray(opts.hosts)) {
+  } else if (Array.isArray(opts.hosts)) {
     // when passing custom hosts, we need to have a different host index if the number
     // of write/read hosts are different.
     this.hosts.read = clone(opts.hosts);
@@ -505,12 +504,11 @@ AlgoliaSearchCore.prototype._computeRequestHeaders = function(additionalUA, with
  * @return {Promise|undefined} Returns a promise if no callback given
  */
 AlgoliaSearchCore.prototype.search = function(queries, opts, callback) {
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: client.search(arrayOfQueries[, callback])';
 
-  if (!isArray(queries)) {
+  if (!Array.isArray(queries)) {
     throw new Error(usage);
   }
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -57,10 +57,9 @@ Index.prototype.addObject = function(content, objectID, callback) {
 *  content: the server answer that updateAt and taskID
 */
 Index.prototype.addObjects = function(objects, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.addObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -124,10 +123,9 @@ Index.prototype.partialUpdateObject = function(partialObject, createIfNotExists,
 *  content: the server answer that updateAt and taskID
 */
 Index.prototype.partialUpdateObjects = function(objects, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.partialUpdateObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -180,10 +178,9 @@ Index.prototype.saveObject = function(object, callback) {
 *  content: the server answer that updateAt and taskID
 */
 Index.prototype.saveObjects = function(objects, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.saveObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -245,12 +242,11 @@ Index.prototype.deleteObject = function(objectID, callback) {
 *  content: the server answer that contains 3 elements: createAt, taskId and objectID
 */
 Index.prototype.deleteObjects = function(objectIDs, callback) {
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: index.deleteObjects(arrayOfObjectIDs[, callback])';
 
-  if (!isArray(objectIDs)) {
+  if (!Array.isArray(objectIDs)) {
     throw new Error(usage);
   }
 
@@ -905,10 +901,9 @@ Index.prototype.addUserKey = deprecate(function(acls, params, callback) {
 * @see {@link https://www.algolia.com/doc/rest_api#AddIndexKey|Algolia REST API Documentation}
 */
 Index.prototype.addApiKey = function(acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.addApiKey(arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -994,10 +989,9 @@ Index.prototype.updateUserKey = deprecate(function(key, acls, params, callback) 
 * @see {@link https://www.algolia.com/doc/rest_api#UpdateIndexKey|Algolia REST API Documentation}
 */
 Index.prototype.updateApiKey = function(key, acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.updateApiKey(key, arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 

--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -337,12 +337,11 @@ IndexCore.prototype.getObject = function(objectID, attrs, callback) {
 * @param objectIDs the array of unique identifier of objects to retrieve
 */
 IndexCore.prototype.getObjects = function(objectIDs, attributesToRetrieve, callback) {
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: index.getObjects(arrayOfObjectIDs[, callback])';
 
-  if (!isArray(objectIDs)) {
+  if (!Array.isArray(objectIDs)) {
     throw new Error(usage);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,10 +2886,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isarray@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
-
 isbinaryfile@~0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-0.1.9.tgz#15eece35c4ab708d8924da99fb874f2b5cc0b6c4"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

isarray is deprecated. We can use the built-in function Array.isArray directly.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Removed isarray dependency and replaced all usages with Array.isArray.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
