### PR TITLE
feat(deprecation): use console.warn to be more visible

### DIFF
--- a/src/deprecate.js
+++ b/src/deprecate.js
@@ -4,7 +4,7 @@ module.exports = function deprecate(fn, message) {
   function deprecated() {
     if (!warned) {
       /* eslint no-console:0 */
-      console.log(message);
+      console.warn(message);
       warned = true;
     }
 

--- a/src/deprecatedMessage.js
+++ b/src/deprecatedMessage.js
@@ -4,5 +4,5 @@ module.exports = function deprecatedMessage(previousUsage, newUsage) {
     .replace('()', '');
 
   return 'algoliasearch: `' + previousUsage + '` was replaced by `' + newUsage +
-    '`. Please see https://github.com/algolia/algoliasearch-client-js/wiki/Deprecated#' + githubAnchorLink;
+    '`. Please see https://github.com/algolia/algoliasearch-client-javascript/wiki/Deprecated#' + githubAnchorLink;
 };


### PR DESCRIPTION

**Summary**

Use console.warn rather than console.log This is the same thing as Facebook uses for React, and is more visible than a simple console.log. It is [supported](https://developer.mozilla.org/en-US/docs/Web/API/Console/warn#Browser_compatibility) in IE8, so that should be fine

Slightly related to #569

**Result**

Deprecation warnings are now in yellow and marked as a warning so we can remove them with more ease later. 