### PR TITLE
feat(headers): add functions to remove and get extra headers

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -111,7 +111,7 @@ function AlgoliaSearchCore(applicationID, apiKey, opts) {
   this.hosts.read = map(this.hosts.read, prepareHost(protocol));
   this.hosts.write = map(this.hosts.write, prepareHost(protocol));
 
-  this.extraHeaders = [];
+  this.extraHeaders = {};
 
   // In some situations you might want to warm the cache
   this.cache = opts._cache || {};
@@ -142,9 +142,25 @@ AlgoliaSearchCore.prototype.initIndex = function(indexName) {
 * @param value the header field value
 */
 AlgoliaSearchCore.prototype.setExtraHeader = function(name, value) {
-  this.extraHeaders.push({
-    name: name.toLowerCase(), value: value
-  });
+  this.extraHeaders[name.toLowerCase()] = value;
+};
+
+/**
+* Get the value of an extra HTTP header
+*
+* @param name the header field name
+*/
+AlgoliaSearchCore.prototype.getExtraHeader = function(name) {
+  return this.extraHeaders[name.toLowerCase()];
+};
+
+/**
+* Remove an extra field from the HTTP request
+*
+* @param name the header field name
+*/
+AlgoliaSearchCore.prototype.unsetExtraHeader = function(name) {
+  delete this.extraHeaders[name.toLowerCase()];
 };
 
 /**
@@ -486,11 +502,9 @@ AlgoliaSearchCore.prototype._computeRequestHeaders = function(additionalUA, with
     requestHeaders['x-algolia-tagfilters'] = this.securityTags;
   }
 
-  if (this.extraHeaders) {
-    forEach(this.extraHeaders, function addToRequestHeaders(header) {
-      requestHeaders[header.name] = header.value;
-    });
-  }
+  forEach(this.extraHeaders, function addToRequestHeaders(value, key) {
+    requestHeaders[key] = value;
+  });
 
   return requestHeaders;
 };

--- a/test/spec/common/client/interface.js
+++ b/test/spec/common/client/interface.js
@@ -20,25 +20,24 @@ test('AlgoliaSearch client API spec', function(t) {
 
   var expectedProperties = [
     'addAlgoliaAgent',
-    'addQueryInBatch',
     'addApiKey',
+    'addQueryInBatch',
     'addUserKey',
     'addUserKeyWithValidity',
     'batch',
-    'updateApiKey',
-    'updateUserKey',
     'clearCache',
     'copyIndex',
-    'deleteIndex',
     'deleteApiKey',
+    'deleteIndex',
     'deleteUserKey',
+    'getApiKey',
+    'getExtraHeader',
     'getLogs',
     'getTimeouts',
-    'getApiKey',
     'getUserKeyACL',
     'initIndex',
-    'listIndexes',
     'listApiKeys',
+    'listIndexes',
     'listUserKeys',
     'moveIndex',
     'search',
@@ -48,10 +47,13 @@ test('AlgoliaSearch client API spec', function(t) {
     'setSecurityTags',
     'setTimeouts',
     'setUserToken',
-    'startQueriesBatch'
+    'startQueriesBatch',
+    'unsetExtraHeader',
+    'updateApiKey',
+    'updateUserKey'
   ];
 
-  // Node.js only methods, not added conditionnaly because
+  // Node.js only methods, not added conditionally because
   // they are still declared in other environments,
   // but they will throw
   expectedProperties = expectedProperties.concat([

--- a/test/spec/common/client/setExtraHeader.js
+++ b/test/spec/common/client/setExtraHeader.js
@@ -3,7 +3,7 @@
 var test = require('tape');
 
 test('client.setExtraHeader(key, value)', function(t) {
-  t.plan(4);
+  t.plan(8);
 
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
@@ -20,25 +20,49 @@ test('client.setExtraHeader(key, value)', function(t) {
 
   client.setExtraHeader('X-great-header', 'yay');
 
+  t.equal(
+    client.getExtraHeader('X-great-header'),
+    'yay',
+    'The `X-great-header` is set on the first search'
+  );
+
   // extra header set
   index.search('second');
 
   client.setExtraHeader('X-great-header', 'yaw');
 
+  t.equal(
+    client.getExtraHeader('X-great-header'),
+    'yaw',
+    'The `X-great-header` is set on the second search'
+  );
+
   // extra header set
   index.search('third');
 
-  fauxJax.waitFor(3, function(err, requests) {
+  client.unsetExtraHeader('X-great-header');
+
+  t.notOk(
+    client.getExtraHeader('X-great-header'),
+    'No `X-great-header` set on fourth search'
+  );
+
+  // extra header removed
+  index.search('fourth');
+
+  fauxJax.waitFor(4, function(err, requests) {
     t.error(err);
     fauxJax.restore();
 
     var firstRequest = requests[0];
     var secondRequest = requests[1];
     var thirdRequest = requests[2];
+    var fourthRequest = requests[3];
 
     firstRequest.respond(200, {}, '{}');
     secondRequest.respond(200, {}, '{}');
     thirdRequest.respond(200, {}, '{}');
+    fourthRequest.respond(200, {}, '{}');
 
     if (process.browser) {
       t.notOk(
@@ -57,6 +81,11 @@ test('client.setExtraHeader(key, value)', function(t) {
         'yaw',
         '`X-great-header` set on third request'
       );
+
+      t.notOk(
+        parse(fourthRequest.requestURL, true).query['x-great-header'],
+        'No `X-great-header` set on fourth request'
+      );
     } else {
       t.notOk(
         firstRequest.requestHeaders['x-great-header'],
@@ -73,6 +102,11 @@ test('client.setExtraHeader(key, value)', function(t) {
         thirdRequest.requestHeaders['x-great-header'],
         'yaw',
         '`X-great-header` set on third request'
+      );
+
+      t.notOk(
+        fourthRequest.requestHeaders['x-great-header'],
+        'No `X-great-header` set on fourth request'
       );
     }
   });


### PR DESCRIPTION
**Summary**

There's no way to check an extra header or remove one, so that needed to be done

**Result**

```js
client.setExtraHeader('X-cool-header','hello there');
client.getExtraHeader('X-cool-header'); //hello there
client.deleteExtraHeader('X-cool-header');
client.getExtraHeader('X-cool-header'); //undefined
```

Do I need to add more documentation for this somewhere?

cc @alexandremeunier 

closes #571 