### PR TITLE
chore(deprecation): remove deprecation message from singular methods

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -28,7 +28,7 @@ inherits(Index, IndexCore);
 *  error: null or Error('message')
 *  content: the server answer that contains 3 elements: createAt, taskId and objectID
 */
-Index.prototype.addObject = deprecate(function(content, objectID, callback) {
+Index.prototype.addObject = function(content, objectID, callback) {
   var indexObj = this;
 
   if (arguments.length === 1 || typeof objectID === 'function') {
@@ -46,7 +46,7 @@ Index.prototype.addObject = deprecate(function(content, objectID, callback) {
     hostType: 'write',
     callback: callback
   });
-}, deprecatedMessage('index.addObject(obj)', 'index.addObjects([obj])'));
+};
 
 /*
 * Add several objects
@@ -94,7 +94,7 @@ Index.prototype.addObjects = function(objects, callback) {
 *  error: null or Error('message')
 *  content: the server answer that contains 3 elements: createAt, taskId and objectID
 */
-Index.prototype.partialUpdateObject = deprecate(function(partialObject, createIfNotExists, callback) {
+Index.prototype.partialUpdateObject = function(partialObject, createIfNotExists, callback) {
   if (arguments.length === 1 || typeof createIfNotExists === 'function') {
     callback = createIfNotExists;
     createIfNotExists = undefined;
@@ -113,7 +113,7 @@ Index.prototype.partialUpdateObject = deprecate(function(partialObject, createIf
     hostType: 'write',
     callback: callback
   });
-}, deprecatedMessage('index.partialUpdateObject(obj)', 'partialUpdateObjects([obj])'));
+};
 
 /*
 * Partially Override the content of several objects
@@ -165,7 +165,7 @@ Index.prototype.partialUpdateObjects = function(objects, createIfNotExists, call
 *  error: null or Error('message')
 *  content: the server answer that updateAt and taskID
 */
-Index.prototype.saveObject = deprecate(function(object, callback) {
+Index.prototype.saveObject = function(object, callback) {
   var indexObj = this;
   return this.as._jsonRequest({
     method: 'PUT',
@@ -174,7 +174,7 @@ Index.prototype.saveObject = deprecate(function(object, callback) {
     hostType: 'write',
     callback: callback
   });
-}, deprecatedMessage('index.saveObject(obj)', 'index.saveObjects([obj])'));
+}
 
 /*
 * Override the content of several objects
@@ -221,7 +221,7 @@ Index.prototype.saveObjects = function(objects, callback) {
 *  error: null or Error('message')
 *  content: the server answer that contains 3 elements: createAt, taskId and objectID
 */
-Index.prototype.deleteObject = deprecate(function(objectID, callback) {
+Index.prototype.deleteObject = function(objectID, callback) {
   if (typeof objectID === 'function' || typeof objectID !== 'string' && typeof objectID !== 'number') {
     var err = new errors.AlgoliaSearchError('Cannot delete an object without an objectID');
     callback = objectID;
@@ -239,7 +239,7 @@ Index.prototype.deleteObject = deprecate(function(objectID, callback) {
     hostType: 'write',
     callback: callback
   });
-}, deprecatedMessage('index.deleteObject(objectID)', 'index.deleteObjects([objectID])'));
+};
 
 /*
 * Delete several objects from an index

--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -304,7 +304,7 @@ IndexCore.prototype._search = function(params, url, callback, additionalUA) {
 *  error: null or Error('message')
 *  content: the object to retrieve or the error message if a failure occured
 */
-IndexCore.prototype.getObject = deprecate(function(objectID, attrs, callback) {
+IndexCore.prototype.getObject = function(objectID, attrs, callback) {
   var indexObj = this;
 
   if (arguments.length === 1 || typeof attrs === 'function') {
@@ -329,7 +329,7 @@ IndexCore.prototype.getObject = deprecate(function(objectID, attrs, callback) {
     hostType: 'read',
     callback: callback
   });
-}, deprecatedMessage('index.getObject(objectID)', 'index.getObjects([objectID])'));
+};
 
 /*
 * Get several objects from this index


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The plural and singular  methods are still useful, and will be kept in v4


**Result**

methods no longer deprecated

* getObject
* addObject
* saveObject
* partialUpdateObject
* deleteObject
