### PR TITLE
chore(build): provide jsdelivr the right file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.24.3",
   "description": "AlgoliaSearch API JavaScript client",
   "main": "index.js",
+  "jsdelivr": "./dist/algoliasearch.min.js",
   "browser": {
     "./index.js": "./src/browser/builds/algoliasearch.js",
     "./lite.js": "./src/browser/builds/algoliasearchLite.js"


### PR DESCRIPTION
Otherwise listing is not good: https://www.jsdelivr.com/package/npm/algoliasearch lists
https://cdn.jsdelivr.net/npm/algoliasearch@3.24.3/index.min.js for main file
