### PR TITLE
chore(deprecation): deprecate waitTask --> waitForCompletion

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -532,7 +532,7 @@ Index.prototype.ttAdapter = deprecate(function(params) {
 *  error: null or Error('message')
 *  content: the server answer that contains the list of results
 */
-Index.prototype.waitTask = function(taskID, callback) {
+Index.prototype.waitTask = deprecate(function(taskID, callback) {
   // wait minimum 100ms before retrying
   var baseDelay = 100;
   // wait maximum 5s before retrying
@@ -583,7 +583,7 @@ Index.prototype.waitTask = function(taskID, callback) {
       callback(err);
     }, client._setTimeout || setTimeout);
   }
-};
+}, deprecatedMessage('index.waitTask()', 'index.waitForCompletion()'));
 
 /*
 * This function deletes the index content. Settings and index specific API keys are kept untouched.

--- a/src/Index.js
+++ b/src/Index.js
@@ -531,8 +531,22 @@ Index.prototype.ttAdapter = deprecate(function(params) {
 * @param callback the result callback with with two arguments:
 *  error: null or Error('message')
 *  content: the server answer that contains the list of results
+* @deprecated see index.waitForCompletion
 */
 Index.prototype.waitTask = deprecate(function(taskID, callback) {
+  return this.waitForCompletion(taskID, callback);
+}, deprecatedMessage('index.waitTask()', 'index.waitForCompletion()'));
+
+/*
+* Wait the publication of a task on the server.
+* All server task are asynchronous and you can check with this method that the task is published.
+*
+* @param taskID the id of the task returned by server
+* @param callback the result callback with with two arguments:
+*  error: null or Error('message')
+*  content: the server answer that contains the list of results
+*/
+Index.prototype.waitForCompletion = function(taskID, callback) {
   // wait minimum 100ms before retrying
   var baseDelay = 100;
   // wait maximum 5s before retrying
@@ -583,7 +597,7 @@ Index.prototype.waitTask = deprecate(function(taskID, callback) {
       callback(err);
     }, client._setTimeout || setTimeout);
   }
-}, deprecatedMessage('index.waitTask()', 'index.waitForCompletion()'));
+}
 
 /*
 * This function deletes the index content. Settings and index specific API keys are kept untouched.

--- a/src/Index.js
+++ b/src/Index.js
@@ -597,7 +597,7 @@ Index.prototype.waitForCompletion = function(taskID, callback) {
       callback(err);
     }, client._setTimeout || setTimeout);
   }
-}
+};
 
 /*
 * This function deletes the index content. Settings and index specific API keys are kept untouched.


### PR DESCRIPTION
We renamed this one in v4 because it's not really proper English

- [x] [wiki entry](https://github.com/algolia/algoliasearch-client-javascript/wiki/Deprecated#indexwaittask)
- [x] alias in v3
- [x] v4 implementation