### PR TITLE
feat(synonyms): exportSynonyms and exportRules

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -636,7 +636,7 @@ Index.prototype.searchSynonyms = function(params, callback) {
   });
 };
 
-function exportData(methodName, _hitsPerPage) {
+function exportData(methodName, _hitsPerPage, callback) {
   function search(page, _previous) {
     var options = {
       page: page || 0,
@@ -657,11 +657,21 @@ function exportData(methodName, _hitsPerPage) {
       return synonyms;
     });
   }
-  return search();
+  return search().then(function(data) {
+    if (typeof callback === 'function') {
+      callback(data);
+    }
+    return data;
+  });
 }
 
-Index.prototype.exportSynonyms = function(hitsPerPage) {
-  return exportData('searchSynonyms', hitsPerPage);
+/**
+ * Retrieve all the synonyms in an index
+ * @param [number=100] hitsPerPage The amount of synonyms to retrieve per batch
+ * @param [function] callback will be called after all synonyms are retrieved
+ */
+Index.prototype.exportSynonyms = function(hitsPerPage, callback) {
+  return exportData('searchSynonyms', hitsPerPage, callback);
 };
 
 Index.prototype.saveSynonym = function(synonym, opts, callback) {
@@ -772,9 +782,13 @@ Index.prototype.searchRules = function(params, callback) {
     callback: callback
   });
 };
-
-Index.prototype.exportRules = function(hitsPerPage) {
-  return exportData('searchRules', hitsPerPage);
+/**
+ * Retrieve all the query rules in an index
+ * @param [number=100] hitsPerPage The amount of query rules to retrieve per batch
+ * @param [function] callback will be called after all query rules are retrieved
+ */
+Index.prototype.exportRules = function(hitsPerPage, callback) {
+  return exportData('searchRules', hitsPerPage, callback);
 };
 
 Index.prototype.saveRule = function(rule, opts, callback) {

--- a/src/Index.js
+++ b/src/Index.js
@@ -636,14 +636,15 @@ Index.prototype.searchSynonyms = function(params, callback) {
   });
 };
 
-function exportData(methodName, _hitsPerPage, callback) {
+function exportData(method, _hitsPerPage, callback) {
   function search(page, _previous) {
     var options = {
       page: page || 0,
       hitsPerPage: _hitsPerPage || 100
     };
     var previous = _previous || [];
-    return Index.prototype[methodName](options).then(function(result) {
+
+    return method(options).then(function(result) {
       var hits = result.hits;
       var nbHits = result.nbHits;
       var current = hits.map(function(s) {
@@ -671,7 +672,7 @@ function exportData(methodName, _hitsPerPage, callback) {
  * @param [function] callback will be called after all synonyms are retrieved
  */
 Index.prototype.exportSynonyms = function(hitsPerPage, callback) {
-  return exportData('searchSynonyms', hitsPerPage, callback);
+  return exportData(this.searchSynonyms, hitsPerPage, callback);
 };
 
 Index.prototype.saveSynonym = function(synonym, opts, callback) {
@@ -788,7 +789,7 @@ Index.prototype.searchRules = function(params, callback) {
  * @param [function] callback will be called after all query rules are retrieved
  */
 Index.prototype.exportRules = function(hitsPerPage, callback) {
-  return exportData('searchRules', hitsPerPage, callback);
+  return exportData(this.searchRules, hitsPerPage, callback);
 };
 
 Index.prototype.saveRule = function(rule, opts, callback) {

--- a/src/Index.js
+++ b/src/Index.js
@@ -643,7 +643,7 @@ function exportData(methodName, _hitsPerPage, callback) {
       hitsPerPage: _hitsPerPage || 100
     };
     var previous = _previous || [];
-    return this[methodName](options).then(function(result) {
+    return Index.prototype[methodName](options).then(function(result) {
       var hits = result.hits;
       var nbHits = result.nbHits;
       var current = hits.map(function(s) {

--- a/src/Index.js
+++ b/src/Index.js
@@ -653,7 +653,7 @@ function exportData(method, _hitsPerPage, callback) {
       });
       var synonyms = previous.concat(current);
       if (synonyms.length < nbHits) {
-        return search(page + 1, synonyms);
+        return search(options.page + 1, synonyms);
       }
       return synonyms;
     });

--- a/src/Index.js
+++ b/src/Index.js
@@ -636,14 +636,6 @@ Index.prototype.searchSynonyms = function(params, callback) {
   });
 };
 
-function _objectWithoutProperties(obj, keys) {
-  return Object.keys(obj).reduce(function(acc, i) {
-    if (keys.indexOf(i) >= 0) return acc;
-    acc[i] = obj[i];
-    return acc;
-  }, {});
-}
-
 function exportData(methodName, _hitsPerPage) {
   function search(page, _previous) {
     var options = {
@@ -655,7 +647,8 @@ function exportData(methodName, _hitsPerPage) {
       var hits = result.hits;
       var nbHits = result.nbHits;
       var current = hits.map(function(s) {
-        return _objectWithoutProperties(s, ['_highlightResult']);
+        delete s._highlightResult;
+        return s;
       });
       var synonyms = previous.concat(current);
       if (synonyms.length < nbHits) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -494,7 +494,13 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
+      console.log('---\nThis is the exported now\n---');
+      console.log(exported);
       exported.sort(sortByObjectId);
+      console.log('---\nThis is the exported after sorting\n---');
+      console.log(exported);
+      console.log('---\nThis is the batch\n---');
+      console.log(rulesBatch);
       t.equal(exported, rulesBatch);
     })
     .then(_.bind(t.end, t))
@@ -530,7 +536,13 @@ function exportSynonyms(t) {
     // now the exported synonyms should be the same
     .then(index.exportSynonyms)
     .then(function(exported) {
+      console.log('---\nThis is the exported now\n---');
+      console.log(exported);
       exported.sort(sortByObjectId);
+      console.log('---\nThis is the exported after sorting\n---');
+      console.log(exported);
+      console.log('---\nThis is the batch\n---');
+      console.log(synonymBatch);
       t.equal(exported, synonymBatch);
     })
     .then(_.bind(t.end, t))

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -58,12 +58,12 @@ test('index.browseAll', browseAll);
 
 if (canPUT) {
   test('synonyms API', synonyms);
-  test.skip('query rules', queryRules);
+  test('query rules', queryRules);
 }
 
 if (canPUT) {
   test('export synonyms', exportSynonyms);
-  test.skip('export query rules', exportRules);
+  test('export query rules', exportRules);
 }
 
 if (!isABrowser) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -34,7 +34,8 @@ var indexName = '_travis-algoliasearch-client-js' +
   chance.word({length: 12});
 
 var client = algoliasearch(appId, apiKey, {
-  protocol: 'https:'
+  protocol: 'https:',
+  _useCache: false
 });
 var index = client.initIndex(indexName);
 var objects = getFakeObjects(50);
@@ -429,7 +430,6 @@ function queryRules(t) {
     .then(index.waitTask)
     .then(_.bind(t.pass, t, 'we batch added rules'))
     // we search and try to hit the query rule pattern
-    .then(client.clearCache)
     .then(_.partial(index.search, {query: 'hellomyfriendhowareyou???'}))
     .then(function(res) {
       t.equal(res.hits.length, 1);

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -59,7 +59,7 @@ test('index.browseAll', browseAll);
 
 if (canPUT) {
   test('synonyms API', synonyms);
-  test.only('query rules', queryRules);
+  test('query rules', queryRules);
 }
 
 if (canPUT) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -497,11 +497,7 @@ function exportRules(t) {
       console.log('---\nThis is the exported now\n---');
       console.log(exported);
       exported.sort(sortByObjectID);
-      console.log('---\nThis is the exported after sorting\n---');
-      console.log(exported);
-      console.log('---\nThis is the batch\n---');
-      console.log(rulesBatch);
-      t.equal(exported, rulesBatch);
+      t.deepEqual(exported, rulesBatch);
     })
     .then(_.bind(t.end, t))
     .catch(_.bind(t.error, t));
@@ -544,11 +540,7 @@ function exportSynonyms(t) {
       console.log('---\nThis is the exported now\n---');
       console.log(exported);
       exported.sort(sortByObjectID);
-      console.log('---\nThis is the exported after sorting\n---');
-      console.log(exported);
-      console.log('---\nThis is the batch\n---');
-      console.log(synonymBatch);
-      t.equal(exported, synonymBatch);
+      t.deepEqual(exported, synonymBatch);
     })
     .then(_.bind(t.end, t))
     .catch(_.bind(t.error, t));

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -473,7 +473,7 @@ function queryRules(t) {
 function exportRules(t) {
   var rulesBatch = Array.from({length: 300}, function(v, num) {
     return {
-      objectID: 'to-integration-test-' + num,
+      objectID: 'some-qr-rule' + num,
       condition: {pattern: 'hellomyfriendhowareyou??? ' + num, anchoring: 'is'},
       consequence: {params: {query: 'query-rule-integration-test'}}
     };
@@ -508,7 +508,12 @@ function exportRules(t) {
 }
 
 function sortByObjectId(a, b) {
-  return a.objectID - b.objectID;
+  function getNum(string) {
+    var lengthToDiscard = 'some-qr-rule-'.length;
+    var number = string.substring(lengthToDiscard);
+    return parseInt(number, 10);
+  }
+  return getNum(a.objectID) - getNum(b.objectID);
 }
 
 function exportSynonyms(t) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -62,8 +62,8 @@ if (canPUT) {
 }
 
 if (canPUT) {
-  test.skip('export synonyms', exportSynonyms);
-  test('export query rules', exportRules);
+  test('export synonyms', exportSynonyms);
+  test.skip('export query rules', exportRules);
 }
 
 if (!isABrowser) {
@@ -477,7 +477,7 @@ function exportRules(t) {
       condition: {pattern: 'hellomyfriendhowareyou??? ' + num, anchoring: 'is'},
       consequence: {params: {query: 'query-rule-integration-test'}}
     };
-  }).sort(sortByObjectId);
+  }).sort(sortByObjectID);
 
   index
     // we clean the index
@@ -496,7 +496,7 @@ function exportRules(t) {
     .then(function(exported) {
       console.log('---\nThis is the exported now\n---');
       console.log(exported);
-      exported.sort(sortByObjectId);
+      exported.sort(sortByObjectID);
       console.log('---\nThis is the exported after sorting\n---');
       console.log(exported);
       console.log('---\nThis is the batch\n---');
@@ -507,7 +507,7 @@ function exportRules(t) {
     .catch(_.bind(t.error, t));
 }
 
-function sortByObjectId(a, b) {
+function sortByObjectID(a, b) {
   function getNum(string) {
     var lengthToDiscard = 'some-qr-rule-'.length;
     var number = string.substring(lengthToDiscard);
@@ -524,7 +524,7 @@ function exportSynonyms(t) {
       placeholder: `<gotcha${num}>`,
       replacements: [`replacement number ${num}`]
     };
-  }).sort(sortByObjectId);
+  }).sort(sortByObjectID);
 
   index
     // we clean the index
@@ -543,7 +543,7 @@ function exportSynonyms(t) {
     .then(function(exported) {
       console.log('---\nThis is the exported now\n---');
       console.log(exported);
-      exported.sort(sortByObjectId);
+      exported.sort(sortByObjectID);
       console.log('---\nThis is the exported after sorting\n---');
       console.log(exported);
       console.log('---\nThis is the batch\n---');

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -477,7 +477,7 @@ function exportRules(t) {
       condition: {pattern: 'hellomyfriendhowareyou??? ' + num, anchoring: 'is'},
       consequence: {params: {query: 'query-rule-integration-test'}}
     };
-  });
+  }).sort(sortByObjectId);
 
   index
     // we clean the index
@@ -494,10 +494,15 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
+      exported.sort(sortByObjectId);
       t.equal(exported, rulesBatch);
     })
     .then(_.bind(t.end, t))
     .catch(_.bind(t.error, t));
+}
+
+function sortByObjectId(a, b) {
+  return a.objectID - b.objectID;
 }
 
 function exportSynonyms(t) {
@@ -508,7 +513,7 @@ function exportSynonyms(t) {
       placeholder: `<gotcha${num}>`,
       replacements: [`replacement number ${num}`]
     };
-  });
+  }).sort(sortByObjectId);
 
   index
     // we clean the index
@@ -525,6 +530,7 @@ function exportSynonyms(t) {
     // now the exported synonyms should be the same
     .then(index.exportSynonyms)
     .then(function(exported) {
+      exported.sort(sortByObjectId);
       t.equal(exported, synonymBatch);
     })
     .then(_.bind(t.end, t))

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -494,8 +494,6 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
-      console.log('---\nThis is the exported now\n---');
-      console.log(exported);
       exported.sort(sortByObjectID);
       t.deepEqual(exported, rulesBatch);
     })
@@ -537,8 +535,6 @@ function exportSynonyms(t) {
     // now the exported synonyms should be the same
     .then(index.exportSynonyms)
     .then(function(exported) {
-      console.log('---\nThis is the exported now\n---');
-      console.log(exported);
       exported.sort(sortByObjectID);
       t.deepEqual(exported, synonymBatch);
     })

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -473,7 +473,7 @@ function queryRules(t) {
 function exportRules(t) {
   var rulesBatch = Array.from({length: 300}, function(v, num) {
     return {
-      objectID: 'some-qr-rule' + num,
+      objectID: 'some-qr-rule-' + num,
       condition: {pattern: 'hellomyfriendhowareyou??? ' + num, anchoring: 'is'},
       consequence: {params: {query: 'query-rule-integration-test'}}
     };

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -514,10 +514,10 @@ function sortByObjectID(a, b) {
 function exportSynonyms(t) {
   var synonymBatch = Array.from({length: 300}, function(v, num) {
     return {
-      objectID: `some-synonym-${num}`,
+      objectID: 'some-synonym-' + num,
       type: 'placeholder',
-      placeholder: `<gotcha${num}>`,
-      replacements: [`replacement number ${num}`]
+      placeholder: '<gotcha' + num + '>',
+      replacements: ['replacement number ' + num]
     };
   }).sort(sortByObjectID);
 

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -58,7 +58,7 @@ test('index.browseAll', browseAll);
 
 if (canPUT) {
   test('synonyms API', synonyms);
-  test('query rules', queryRules);
+  test.only('query rules', queryRules);
 }
 
 if (canPUT) {
@@ -429,6 +429,7 @@ function queryRules(t) {
     .then(index.waitTask)
     .then(_.bind(t.pass, t, 'we batch added rules'))
     // we search and try to hit the query rule pattern
+    .then(client.clearCache)
     .then(_.partial(index.search, {query: 'hellomyfriendhowareyou???'}))
     .then(function(res) {
       t.equal(res.hits.length, 1);
@@ -494,6 +495,7 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
+      console.log(exported)
       exported.sort(sortByObjectID);
       t.deepEqual(exported, rulesBatch);
     })

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -495,7 +495,6 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
-      console.log(exported)
       exported.sort(sortByObjectID);
       t.deepEqual(exported, rulesBatch);
     })

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -494,7 +494,7 @@ function exportRules(t) {
     // now the exported rules should be the same
     .then(index.exportRules)
     .then(function(exported) {
-      t.equal(rulesBatch, exported);
+      t.equal(exported, rulesBatch);
     })
     .then(_.bind(t.end, t))
     .catch(_.bind(t.error, t));
@@ -525,7 +525,7 @@ function exportSynonyms(t) {
     // now the exported synonyms should be the same
     .then(index.exportSynonyms)
     .then(function(exported) {
-      t.equal(synonymBatch, exported);
+      t.equal(exported, synonymBatch);
     })
     .then(_.bind(t.end, t))
     .catch(_.bind(t.error, t));

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -62,8 +62,8 @@ if (canPUT) {
 }
 
 if (canPUT) {
-  test('export synonyms', exportSynonyms);
-  test.skip('export query rules', exportRules);
+  test.skip('export synonyms', exportSynonyms);
+  test('export query rules', exportRules);
 }
 
 if (!isABrowser) {

--- a/test/spec/common/client/interface.js
+++ b/test/spec/common/client/interface.js
@@ -30,6 +30,8 @@ test('AlgoliaSearch client API spec', function(t) {
     'deleteApiKey',
     'deleteIndex',
     'deleteUserKey',
+    'exportRules',
+    'exportSynonyms',
     'getApiKey',
     'getExtraHeader',
     'getLogs',

--- a/test/spec/common/client/interface.js
+++ b/test/spec/common/client/interface.js
@@ -30,8 +30,6 @@ test('AlgoliaSearch client API spec', function(t) {
     'deleteApiKey',
     'deleteIndex',
     'deleteUserKey',
-    'exportRules',
-    'exportSynonyms',
     'getApiKey',
     'getExtraHeader',
     'getLogs',

--- a/test/spec/common/index/interface.js
+++ b/test/spec/common/index/interface.js
@@ -42,6 +42,8 @@ test('AlgoliaSearch index API spec', function(t) {
     'deleteRule',
     'deleteApiKey',
     'deleteUserKey',
+    'exportSynonyms',
+    'exportRules',
     'getObject',
     'getObjects',
     'getSettings',


### PR DESCRIPTION

in v4 we will rework this under algoliasearch-extras with as much control as needed, similar for browseAll

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

exportSynonyms and exportRules will get all of the synonyms / rules on an index

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

both implemented naively with the only way to control the flow being specifying hitsPerPage

**Test plan**

```js
index.batchRules([someRules]);
index.searchRules(hitsPerPage?: number).then(saveToFile);
// same for synonyms
```