### PR TITLE
feat(copyIndex): back-compatible add of scope

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -57,14 +57,23 @@ AlgoliaSearch.prototype.moveIndex = function(srcIndexName, dstIndexName, callbac
  * @param srcIndexName the name of index to copy.
  * @param dstIndexName the new index name that will contains a copy
  * of srcIndexName (destination will be overriten if it already exist).
+ * @param scope an array of scopes to copy: ['settings', 'synonyms', 'rules']
  * @param callback the result callback called with two arguments
  *  error: null or Error('message')
  *  content: the server answer that contains the task ID
  */
-AlgoliaSearch.prototype.copyIndex = function(srcIndexName, dstIndexName, callback) {
+AlgoliaSearch.prototype.copyIndex = function(srcIndexName, dstIndexName, scopeOrCallback, _callback) {
   var postObj = {
-    operation: 'copy', destination: dstIndexName
+    operation: 'copy',
+    destination: dstIndexName
   };
+  var callback = _callback;
+  if (typeof scopeOrCallback === 'function') {
+    // oops, old behaviour of third argument being a function
+    callback = scopeOrCallback;
+  } else if (Array.isArray(scopeOrCallback) && scopeOrCallback.length > 0) {
+    postObj.scope = scopeOrCallback;
+  }
   return this._jsonRequest({
     method: 'POST',
     url: '/1/indexes/' + encodeURIComponent(srcIndexName) + '/operation',

--- a/test/spec/common/client/test-cases/copyIndex.js
+++ b/test/spec/common/client/test-cases/copyIndex.js
@@ -1,17 +1,65 @@
 'use strict';
 
-module.exports = {
-  testName: 'client.copyIndex(from, to, cb)',
-  object: 'client',
-  methodName: 'copyIndex',
-  callArguments: ['from index', 'to index'],
-  action: 'write',
-  expectedRequest: {
-    method: 'POST',
-    URL: {pathname: '/1/indexes/from%20index/operation'},
-    body: {
-      operation: 'copy',
-      destination: 'to index'
+module.exports = [
+  {
+    testName: 'client.copyIndex(from, to, cb)',
+    object: 'client',
+    methodName: 'copyIndex',
+    callArguments: ['from index', 'to index'],
+    action: 'write',
+    expectedRequest: {
+      method: 'POST',
+      URL: {pathname: '/1/indexes/from%20index/operation'},
+      body: {
+        operation: 'copy',
+        destination: 'to index'
+      }
+    }
+  },
+  {
+    testName: 'client.copyIndex(from, to, scope)',
+    object: 'client',
+    methodName: 'copyIndex',
+    callArguments: ['from index', 'to index', ['settings']],
+    action: 'write',
+    expectedRequest: {
+      method: 'POST',
+      URL: {pathname: '/1/indexes/from%20index/operation'},
+      body: {
+        operation: 'copy',
+        destination: 'to index',
+        scope: ['settings']
+      }
+    }
+  },
+  {
+    testName: 'client.copyIndex(from, to, [])',
+    object: 'client',
+    methodName: 'copyIndex',
+    callArguments: ['from index', 'to index', []],
+    action: 'write',
+    expectedRequest: {
+      method: 'POST',
+      URL: {pathname: '/1/indexes/from%20index/operation'},
+      body: {
+        operation: 'copy',
+        destination: 'to index'
+      }
+    }
+  },
+  {
+    testName: 'client.copyIndex(from, to, undefined)',
+    object: 'client',
+    methodName: 'copyIndex',
+    callArguments: ['from index', 'to index', undefined],
+    action: 'write',
+    expectedRequest: {
+      method: 'POST',
+      URL: {pathname: '/1/indexes/from%20index/operation'},
+      body: {
+        operation: 'copy',
+        destination: 'to index'
+      }
     }
   }
-};
+];


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

copyIndex accepts an optional third argument with the scope

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

copyIndex can now accept a third parameter (scope) which is an array with values 'settings', 'synonyms', 'rules'. An empty array is treated as not given, since the api otherwise returns an error, and I have the feeling that this might be what people expect.

You can still have the callback as third argument if you want, or leave the third undefined and put it in the fourth position.

I added new tests with a valid array, empty array and undefined.

Wanted to test if callback is accepted on both position 3 and 4, but that seems to be quite hard, so for now I'll just let this be.