### PR TITLE
fix(copyIndex): don't throw if no scope at all is given

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -73,7 +73,7 @@ AlgoliaSearch.prototype.copyIndex = function(srcIndexName, dstIndexName, scopeOr
     callback = scopeOrCallback;
   } else if (Array.isArray(scopeOrCallback) && scopeOrCallback.length > 0) {
     postObj.scope = scopeOrCallback;
-  } else {
+  } else if (typeof scopeOrCallback !== 'undefined') {
     throw new Error('the scope given to `copyIndex` was not an array with settings, synonyms or rules');
   }
   return this._jsonRequest({


### PR DESCRIPTION
cc @proudlygeek

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If no scope was given to copyIndex, an error was thrown. This was intended for cases where the scope is an empty array or something else wrong. `undefined` however is correct behaviour

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

don't throw if the scope is `undefined`