### PR TITLE
fix(core): make sure api key is sent as body if > 500 chars

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -488,7 +488,7 @@ AlgoliaSearchCore.prototype._getSearchParams = function(args, params) {
  * Compute the headers for a request
  *
  * @param [string] options.additionalUA semi-colon separated string with other user agents to add
- * @param [boolean=true] options.withAPIKey Send the api key as a header
+ * @param [boolean=true] options.withApiKey Send the api key as a header
  * @param [Object] options.headers Extra headers to send
  */
 AlgoliaSearchCore.prototype._computeRequestHeaders = function(options) {
@@ -507,7 +507,7 @@ AlgoliaSearchCore.prototype._computeRequestHeaders = function(options) {
   // but in some situations, the API KEY will be too long (big secured API keys)
   // so if the request is a POST and the KEY is very long, we will be asked to not put
   // it into headers but in the JSON body
-  if (options.withAPIKey !== false) {
+  if (options.withApiKey !== false) {
     requestHeaders['x-algolia-api-key'] = this.apiKey;
   }
 


### PR DESCRIPTION
This wasn't the case in the latest patch, because `withAPIKey` is not the same as `withApiKey`. I thought the bug was way worse before I selected the text and wondered why there were only two 'matches' in my editor, rather than three, which I knew was the case. Anyway, long story short, it was just a typo

fixes #647
