### PR TITLE
feat(getSettings): allow `advanced=1`

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -608,11 +608,20 @@ Index.prototype.clearIndex = function(callback) {
 *  error: null or Error('message')
 *  content: the settings object or the error message if a failure occured
 */
-Index.prototype.getSettings = function(callback) {
-  var indexObj = this;
+Index.prototype.getSettings = function(opts, callback) {
+  if (arguments.length === 1 || typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+
+  var indexName = encodeURIComponent(this.indexName);
   return this.as._jsonRequest({
     method: 'GET',
-    url: '/1/indexes/' + encodeURIComponent(indexObj.indexName) + '/settings?getVersion=2',
+    url:
+      '/1/indexes/' +
+      indexName +
+      '/settings?getVersion=2' +
+      (opts.advanced ? '&advanced=' + opts.advanced : ''),
     hostType: 'read',
     callback: callback
   });

--- a/test/spec/common/index/test-cases/getSettings.js
+++ b/test/spec/common/index/test-cases/getSettings.js
@@ -1,17 +1,36 @@
 'use strict';
 
-module.exports = {
-  object: 'index',
-  methodName: 'getSettings',
-  testName: 'index.getSettings(cb)',
-  action: 'read',
-  expectedRequest: {
-    method: 'GET',
-    URL: {
-      pathname: '/1/indexes/%s/settings',
-      query: {
-        getVersion: '2'
+module.exports = [
+  {
+    object: 'index',
+    methodName: 'getSettings',
+    testName: 'index.getSettings(cb)',
+    action: 'read',
+    expectedRequest: {
+      method: 'GET',
+      URL: {
+        pathname: '/1/indexes/%s/settings',
+        query: {
+          getVersion: '2'
+        }
+      }
+    }
+  },
+  {
+    object: 'index',
+    methodName: 'getSettings',
+    testName: 'index.getSettings({ advanced: 1 }, cb)',
+    callArguments: [{advanced: 1}],
+    action: 'read',
+    expectedRequest: {
+      method: 'GET',
+      URL: {
+        pathname: '/1/indexes/%s/settings',
+        query: {
+          getVersion: '2',
+          advanced: '1'
+        }
       }
     }
   }
-};
+];


### PR DESCRIPTION


cc @seafoox

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

There was no way to ask for `?advanced=1` in `getSettings`

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

a first parameter to `getSettings` (with fallback to the callback) which is an object

if `advanced` is present in the object, it's added to the url

Fixes #637

This is an undocumented parameter, which has enterprise usage, which is why I didn't add it to the docblock.