### PR TITLE
fix(nodejs): handle network errors

### DIFF
--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -175,6 +175,7 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
 
       res
         .on('data', onData)
+        .once('error', reject)
         .once('end', onEnd);
 
       function onData(chunk) {


### PR DESCRIPTION
Before this commit we were not listening for http network errors
that can happen once the connection is opened. Those can happen when you
have a network issue in the middle of a response.

I was able to reproduce this error by launching multiple requests and
unplugging my network altogether.

I would constantly get the infamous "zlib error" which was only an
effect of not being able to continue the response listening.