### PR TITLE
feat(exports): add AlgoliaSearchError to exported module

### DIFF
--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -33,6 +33,7 @@ window.angular.module('algoliasearch', [])
       return new AlgoliaSearchAngular(applicationID, apiKey, opts);
     }
 
+    algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
     algoliasearch.version = require('../../version.js');
     algoliasearch.ua = 'Algolia for AngularJS ' + algoliasearch.version;
     algoliasearch.initPlaces = places(algoliasearch);

--- a/src/browser/builds/algoliasearch.jquery.js
+++ b/src/browser/builds/algoliasearch.jquery.js
@@ -29,6 +29,7 @@ function algoliasearch(applicationID, apiKey, opts) {
   return new AlgoliaSearchJQuery(applicationID, apiKey, opts);
 }
 
+algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
 algoliasearch.version = require('../../version.js');
 algoliasearch.ua = 'Algolia for jQuery ' + algoliasearch.version;
 algoliasearch.initPlaces = places(algoliasearch);

--- a/src/browser/createAlgoliasearch.js
+++ b/src/browser/createAlgoliasearch.js
@@ -28,6 +28,7 @@ module.exports = function createAlgoliasearch(AlgoliaSearch, uaSuffix) {
     return new AlgoliaSearchBrowser(applicationID, apiKey, opts);
   }
 
+  algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
   algoliasearch.version = require('../version.js');
   algoliasearch.ua = 'Algolia for vanilla JavaScript ' + uaSuffix + algoliasearch.version;
   algoliasearch.initPlaces = places(algoliasearch);

--- a/src/reactnative/builds/algoliasearch.reactnative.js
+++ b/src/reactnative/builds/algoliasearch.reactnative.js
@@ -33,6 +33,7 @@ function algoliasearch(applicationID, apiKey, opts) {
   return new AlgoliaSearchReactNative(applicationID, apiKey, opts);
 }
 
+algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
 algoliasearch.version = require('../../version.js');
 algoliasearch.ua = 'Algolia for ReactNative ' + algoliasearch.version;
 algoliasearch.initPlaces = places(algoliasearch);

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -68,6 +68,7 @@ function algoliasearch(applicationID, apiKey, opts) {
   return new AlgoliaSearchNodeJS(applicationID, apiKey, opts);
 }
 
+algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
 algoliasearch.version = require('../../version.js');
 algoliasearch.ua = 'Algolia for Node.js ' + algoliasearch.version;
 algoliasearch.initPlaces = places(algoliasearch);

--- a/src/server/builds/parse.js
+++ b/src/server/builds/parse.js
@@ -45,6 +45,7 @@ function algoliasearch(applicationID, apiKey, opts) {
   return new AlgoliaSearchParse(applicationID, apiKey, opts);
 }
 
+algoliasearch.AlgoliaSearchError = require('../../errors.js').AlgoliaSearchError;
 algoliasearch.version = require('../../version.js');
 algoliasearch.ua = 'Algolia for Parse ' + algoliasearch.version;
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Closes #683

Exposes all internal client errors.
I'm not sure if only `AlgoliaSearchError` can bubble up.
If this is the case, use this PR, otherwise use this one instead: #684

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

```sh
$ node
> require('./index');
{ [Function: algoliasearch]
  AlgoliaSearchError: { [Function: AlgoliaSearchError] super_: { [Function: Error] stackTraceLimit: 10 } },
  version: '3.27.0',
  ua: 'Algolia for Node.js 3.27.0',
  initPlaces: [Function: places] }
```

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->