### PR TITLE
feat: Polyfill `Promise.all()`

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -9,5 +9,11 @@ echo "Test"
 echo "Test: node"
 ./scripts/test-node
 
+#####
+# TODO: remove before merging the PR
+echo "Test: ci"
+./scripts/test-ci
+#####
+
 echo "Test: lint"
 ./scripts/lint

--- a/scripts/test
+++ b/scripts/test
@@ -9,11 +9,5 @@ echo "Test"
 echo "Test: node"
 ./scripts/test-node
 
-#####
-# TODO: remove before merging the PR
-echo "Test: ci"
-./scripts/test-ci
-#####
-
 echo "Test: lint"
 ./scripts/lint

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -636,7 +636,7 @@ AlgoliaSearchCore.prototype.searchForFacetValues = function(queries) {
 
   var client = this;
 
-  return Promise.all(map(queries, function performQuery(query) {
+  return client._promise.all(map(queries, function performQuery(query) {
     if (
       !query ||
       query.indexName === undefined ||

--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -185,6 +185,9 @@ window.angular.module('algoliasearch', [])
         $timeout(resolve, ms);
 
         return deferred.promise;
+      },
+      all: function(promises) {
+        return $q.all(promises);
       }
     };
 

--- a/src/browser/builds/algoliasearch.jquery.js
+++ b/src/browser/builds/algoliasearch.jquery.js
@@ -140,5 +140,8 @@ AlgoliaSearchJQuery.prototype._promise = {
         deferred.resolve();
       }, ms);
     }).promise();
+  },
+  all: function all(promises) {
+    return $.when.apply(null, promises);
   }
 };

--- a/src/browser/createAlgoliasearch.js
+++ b/src/browser/createAlgoliasearch.js
@@ -206,6 +206,9 @@ module.exports = function createAlgoliasearch(AlgoliaSearch, uaSuffix) {
       return new Promise(function resolveOnTimeout(resolve/* , reject*/) {
         setTimeout(resolve, ms);
       });
+    },
+    all: function all(promises) {
+      return Promise.all(promises);
     }
   };
 

--- a/src/reactnative/builds/algoliasearch.reactnative.js
+++ b/src/reactnative/builds/algoliasearch.reactnative.js
@@ -168,5 +168,8 @@ AlgoliaSearchReactNative.prototype._promise = {
     return new Promise(function resolveOnTimeout(resolve/* , reject*/) {
       setTimeout(resolve, ms);
     });
+  },
+  all: function all(promises) {
+    return Promise.all(promises);
   }
 };

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -257,6 +257,9 @@ AlgoliaSearchNodeJS.prototype._promise = {
     return new Promise(function resolveOnTimeout(resolve/* , reject */) {
       setTimeout(resolve, ms);
     });
+  },
+  all: function all(promises) {
+    return Promise.all(promises);
   }
 };
 

--- a/src/server/builds/parse.js
+++ b/src/server/builds/parse.js
@@ -116,6 +116,9 @@ AlgoliaSearchParse.prototype._promise = {
     _setTimeout(promise.resolve.bind(promise), ms);
 
     return promise;
+  },
+  all: function all(promises) {
+    return Parse.Promise.all(promises);
   }
 };
 


### PR DESCRIPTION
## Why

As reported by @vvo, `AlgoliaSearchCore.prototype.searchForFacetValues` does not work in IE11 because we rely on the native [`Promise.all()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) since #677.

## Solution

* Polyfill the `all()` method in each `client._promise` build
* Use `client._promise.all()` instead of `Promise.all()`