### PR TITLE
feat: Enforce Rule.ObjectID not to be empty

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -799,6 +799,7 @@ Index.prototype.searchRules = function(params, callback) {
  * Retrieve all the query rules in an index
  * @param [number=100] hitsPerPage The amount of query rules to retrieve per batch
  * @param [function] callback will be called after all query rules are retrieved
+ *  error: null or Error('message')
  */
 Index.prototype.exportRules = function(hitsPerPage, callback) {
   return exportData(this.searchRules.bind(this), hitsPerPage, callback);
@@ -810,6 +811,10 @@ Index.prototype.saveRule = function(rule, opts, callback) {
     opts = {};
   } else if (opts === undefined) {
     opts = {};
+  }
+
+  if (!rule.objectID) {
+    throw new AlgoliaError('Missing or empty objectID field for rule');
   }
 
   var forwardToReplicas = opts.forwardToReplicas === true ? 'true' : 'false';

--- a/src/Index.js
+++ b/src/Index.js
@@ -814,7 +814,7 @@ Index.prototype.saveRule = function(rule, opts, callback) {
   }
 
   if (!rule.objectID) {
-    throw new AlgoliaError('Missing or empty objectID field for rule');
+    throw new errors.AlgoliaSearchError('Missing or empty objectID field for rule');
   }
 
   var forwardToReplicas = opts.forwardToReplicas === true ? 'true' : 'false';

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -524,12 +524,11 @@ function queryRules(t) {
 }
 
 function emptyObjectIDQueryRule(t) {
-  index
-    .then(_.partial(index.saveRule, {
-      condition: {pattern: 'pattern', anchoring: 'is'},
-      consequence: {params: {query: 'something'}}
-    }))
-  // TODO: Catch the expected error.
+  index.saveRule({
+    condition: {pattern: 'pattern', anchoring: 'is'},
+    consequence: {params: {query: 'something'}}
+  }).then(function() {t.end();})
+    .then(noop, _.bind(t.error, t));
 }
 
 function exportRules(t) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -65,6 +65,8 @@ if (canPUT) {
   test('query rules', queryRules);
 }
 
+test('empty objectID for query rule', emptyObjectIDQueryRule);
+
 if (canPUT) {
   test('export synonyms', exportSynonyms);
   test('export query rules', exportRules);
@@ -519,6 +521,15 @@ function queryRules(t) {
     })
     .then(function() {t.end();})
     .then(noop, _.bind(t.error, t));
+}
+
+function emptyObjectIDQueryRule(t) {
+  index
+    .then(_.partial(index.saveRule, {
+      condition: {pattern: 'pattern', anchoring: 'is'},
+      consequence: {params: {query: 'something'}}
+    }))
+  // TODO: Catch the expected error.
 }
 
 function exportRules(t) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -524,11 +524,12 @@ function queryRules(t) {
 }
 
 function emptyObjectIDQueryRule(t) {
-  index.saveRule({
-    condition: {pattern: 'pattern', anchoring: 'is'},
-    consequence: {params: {query: 'something'}}
-  }).then(function() {t.end();})
-    .then(noop, _.bind(t.error, t));
+  t.throws(function() {
+    index.saveRule({
+      condition: {pattern: 'pattern', anchoring: 'is'},
+      consequence: {params: {query: 'something'}}
+    });
+  }, 'Missing or empty objectID field for rule');
 }
 
 function exportRules(t) {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -524,12 +524,20 @@ function queryRules(t) {
 }
 
 function emptyObjectIDQueryRule(t) {
-  t.throws(function() {
+  try {
     index.saveRule({
       condition: {pattern: 'pattern', anchoring: 'is'},
       consequence: {params: {query: 'something'}}
     });
-  }, 'Missing or empty objectID field for rule');
+  } catch (err) {
+    t.equal(
+      err.message,
+      'Missing or empty objectID field for rule',
+      'Error message matches'
+    );
+    t.ok(err instanceof Error, 'Error was thrown');
+    t.end();
+  }
 }
 
 function exportRules(t) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

We discovered that by adding a new rule with an empty `objectID` field, you are actually targeting the add new record endpoint with a record ID set to `rules`. This PR makes sure we cannot add a new rule with an empty objectID. For more informations, here's the full description: https://github.com/algolia/algoliasearch-client-go/issues/397.

**Result**

Not sure the tests are good nor correctly written. I'm asking for help here.