### PR TITLE
feat: Deprecate API keys methods on Index in favor of Client ones

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -989,11 +989,11 @@ Index.prototype.setSettings = function(settings, opts, callback) {
 };
 
 /*
- @deprecated see index.listApiKeys
- */
+* @deprecated see client.listApiKeys()
+*/
 Index.prototype.listUserKeys = deprecate(function(callback) {
   return this.listApiKeys(callback);
-}, deprecatedMessage('index.listUserKeys()', 'index.listApiKeys()'));
+}, deprecatedMessage('index.listUserKeys()', 'client.listApiKeys()'));
 
 /*
 * List all existing API keys to this index
@@ -1001,8 +1001,10 @@ Index.prototype.listUserKeys = deprecate(function(callback) {
 * @param callback the result callback called with two arguments
 *  error: null or Error('message')
 *  content: the server answer with API keys belonging to the index
+*
+* @deprecated see client.listApiKeys()
 */
-Index.prototype.listApiKeys = function(callback) {
+Index.prototype.listApiKeys = deprecate(function(callback) {
   var indexObj = this;
   return this.as._jsonRequest({
     method: 'GET',
@@ -1010,14 +1012,14 @@ Index.prototype.listApiKeys = function(callback) {
     hostType: 'read',
     callback: callback
   });
-};
+}, deprecatedMessage('index.listApiKeys()', 'client.listApiKeys()'));
 
 /*
- @deprecated see index.getApiKey
- */
+* @deprecated see client.getApiKey()
+*/
 Index.prototype.getUserKeyACL = deprecate(function(key, callback) {
   return this.getApiKey(key, callback);
-}, deprecatedMessage('index.getUserKeyACL()', 'index.getApiKey()'));
+}, deprecatedMessage('index.getUserKeyACL()', 'client.getApiKey()'));
 
 
 /*
@@ -1027,8 +1029,10 @@ Index.prototype.getUserKeyACL = deprecate(function(key, callback) {
 * @param callback the result callback called with two arguments
 *  error: null or Error('message')
 *  content: the server answer with the right API key
+*
+* @deprecated see client.getApiKey()
 */
-Index.prototype.getApiKey = function(key, callback) {
+Index.prototype.getApiKey = deprecate(function(key, callback) {
   var indexObj = this;
   return this.as._jsonRequest({
     method: 'GET',
@@ -1036,14 +1040,14 @@ Index.prototype.getApiKey = function(key, callback) {
     hostType: 'read',
     callback: callback
   });
-};
+}, deprecatedMessage('index.getApiKey()', 'client.getApiKey()'));
 
 /*
- @deprecated see index.deleteApiKey
- */
+* @deprecated see client.deleteApiKey()
+*/
 Index.prototype.deleteUserKey = deprecate(function(key, callback) {
   return this.deleteApiKey(key, callback);
-}, deprecatedMessage('index.deleteUserKey()', 'index.deleteApiKey()'));
+}, deprecatedMessage('index.deleteUserKey()', 'client.deleteApiKey()'));
 
 /*
 * Delete an existing API key associated to this index
@@ -1052,8 +1056,10 @@ Index.prototype.deleteUserKey = deprecate(function(key, callback) {
 * @param callback the result callback called with two arguments
 *  error: null or Error('message')
 *  content: the server answer with the deletion date
+*
+* @deprecated see client.deleteApiKey()
 */
-Index.prototype.deleteApiKey = function(key, callback) {
+Index.prototype.deleteApiKey = deprecate(function(key, callback) {
   var indexObj = this;
   return this.as._jsonRequest({
     method: 'DELETE',
@@ -1061,14 +1067,14 @@ Index.prototype.deleteApiKey = function(key, callback) {
     hostType: 'write',
     callback: callback
   });
-};
+}, deprecatedMessage('index.deleteApiKey()', 'client.deleteApiKey()'));
 
 /*
- @deprecated see index.addApiKey
- */
+* @deprecated see client.addApiKey()
+*/
 Index.prototype.addUserKey = deprecate(function(acls, params, callback) {
   return this.addApiKey(acls, params, callback);
-}, deprecatedMessage('index.addUserKey()', 'index.addApiKey()'));
+}, deprecatedMessage('index.addUserKey()', 'client.addApiKey()'));
 
 /*
 * Add a new API key to this index
@@ -1105,8 +1111,10 @@ Index.prototype.addUserKey = deprecate(function(acls, params, callback) {
 *   }
 * })
 * @see {@link https://www.algolia.com/doc/rest_api#AddIndexKey|Algolia REST API Documentation}
+*
+* @deprecated see client.addApiKey()
 */
-Index.prototype.addApiKey = function(acls, params, callback) {
+Index.prototype.addApiKey = deprecate(function(acls, params, callback) {
   var isArray = require('isarray');
   var usage = 'Usage: index.addApiKey(arrayOfAcls[, params, callback])';
 
@@ -1143,21 +1151,21 @@ Index.prototype.addApiKey = function(acls, params, callback) {
     hostType: 'write',
     callback: callback
   });
-};
+}, deprecatedMessage('index.addApiKey()', 'client.addApiKey()'));
 
 /**
-* @deprecated use index.addApiKey()
+* @deprecated use client.addApiKey()
 */
 Index.prototype.addUserKeyWithValidity = deprecate(function deprecatedAddUserKeyWithValidity(acls, params, callback) {
   return this.addApiKey(acls, params, callback);
-}, deprecatedMessage('index.addUserKeyWithValidity()', 'index.addApiKey()'));
+}, deprecatedMessage('index.addUserKeyWithValidity()', 'client.addApiKey()'));
 
 /*
- @deprecated see index.updateApiKey
- */
+* @deprecated see client.updateApiKey()
+*/
 Index.prototype.updateUserKey = deprecate(function(key, acls, params, callback) {
   return this.updateApiKey(key, acls, params, callback);
-}, deprecatedMessage('index.updateUserKey()', 'index.updateApiKey()'));
+}, deprecatedMessage('index.updateUserKey()', 'client.updateApiKey()'));
 
 /**
 * Update an existing API key of this index
@@ -1194,8 +1202,10 @@ Index.prototype.updateUserKey = deprecate(function(key, acls, params, callback) 
 *   }
 * })
 * @see {@link https://www.algolia.com/doc/rest_api#UpdateIndexKey|Algolia REST API Documentation}
+*
+* @deprecated see client.updateApiKey()
 */
-Index.prototype.updateApiKey = function(key, acls, params, callback) {
+Index.prototype.updateApiKey = deprecate(function(key, acls, params, callback) {
   var isArray = require('isarray');
   var usage = 'Usage: index.updateApiKey(key, arrayOfAcls[, params, callback])';
 
@@ -1232,4 +1242,4 @@ Index.prototype.updateApiKey = function(key, acls, params, callback) {
     hostType: 'write',
     callback: callback
   });
-};
+}, deprecatedMessage('index.updateApiKey()', 'client.updateApiKey()'));


### PR DESCRIPTION
**Summary**

As discussed with @maxiloc and @julienbourdeau, the API key methods are supposed to only be implemented at the client level, not at the index level anymore. This is due to the fact that per-index keys are not available via the dashboard and we do not want users to use them anymore.

**Result**

N/A