### PR TITLE
fix(env): don't assume `process` is defined

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -10,7 +10,9 @@ var store = require('./store.js');
 // proxies limit)
 var MAX_API_KEY_LENGTH = 500;
 var RESET_APP_DATA_TIMER =
-  (process && process.env.RESET_APP_DATA_TIMER && parseInt(process.env.RESET_APP_DATA_TIMER, 10)) ||
+  (typeof process !== 'undefined' &&
+    process.env.RESET_APP_DATA_TIMER &&
+    parseInt(process.env.RESET_APP_DATA_TIMER, 10)) ||
   60 * 2 * 1000; // after 2 minutes reset to first host
 
 /*

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -10,7 +10,7 @@ var store = require('./store.js');
 // proxies limit)
 var MAX_API_KEY_LENGTH = 500;
 var RESET_APP_DATA_TIMER =
-  process.env.RESET_APP_DATA_TIMER && parseInt(process.env.RESET_APP_DATA_TIMER, 10) ||
+  (process && process.env.RESET_APP_DATA_TIMER && parseInt(process.env.RESET_APP_DATA_TIMER, 10)) ||
   60 * 2 * 1000; // after 2 minutes reset to first host
 
 /*

--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -17,7 +17,7 @@ var places = require('../../places.js');
 // expose original algoliasearch fn in window
 window.algoliasearch = require('./algoliasearch');
 
-if (process && process.env.NODE_ENV === 'debug') {
+if (typeof process !== 'undefined' && process.env.NODE_ENV === 'debug') {
   require('debug').enable('algoliasearch*');
 }
 

--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -17,7 +17,7 @@ var places = require('../../places.js');
 // expose original algoliasearch fn in window
 window.algoliasearch = require('./algoliasearch');
 
-if (process.env.NODE_ENV === 'debug') {
+if (process && process.env.NODE_ENV === 'debug') {
   require('debug').enable('algoliasearch*');
 }
 

--- a/src/browser/builds/algoliasearch.jquery.js
+++ b/src/browser/builds/algoliasearch.jquery.js
@@ -15,7 +15,7 @@ var places = require('../../places.js');
 // expose original algoliasearch fn in window
 window.algoliasearch = require('./algoliasearch');
 
-if (process && process.env.NODE_ENV === 'debug') {
+if (process !== 'undefined' && process.env.NODE_ENV === 'debug') {
   require('debug').enable('algoliasearch*');
 }
 

--- a/src/browser/builds/algoliasearch.jquery.js
+++ b/src/browser/builds/algoliasearch.jquery.js
@@ -15,7 +15,7 @@ var places = require('../../places.js');
 // expose original algoliasearch fn in window
 window.algoliasearch = require('./algoliasearch');
 
-if (process.env.NODE_ENV === 'debug') {
+if (process && process.env.NODE_ENV === 'debug') {
   require('debug').enable('algoliasearch*');
 }
 

--- a/src/browser/createAlgoliasearch.js
+++ b/src/browser/createAlgoliasearch.js
@@ -14,7 +14,7 @@ module.exports = function createAlgoliasearch(AlgoliaSearch, uaSuffix) {
   var places = require('../places.js');
   uaSuffix = uaSuffix || '';
 
-  if (process.env.NODE_ENV === 'debug') {
+  if (process && process.env.NODE_ENV === 'debug') {
     require('debug').enable('algoliasearch*');
   }
 

--- a/src/browser/createAlgoliasearch.js
+++ b/src/browser/createAlgoliasearch.js
@@ -14,7 +14,7 @@ module.exports = function createAlgoliasearch(AlgoliaSearch, uaSuffix) {
   var places = require('../places.js');
   uaSuffix = uaSuffix || '';
 
-  if (process && process.env.NODE_ENV === 'debug') {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'debug') {
     require('debug').enable('algoliasearch*');
   }
 

--- a/src/browser/migration-layer/script.js
+++ b/src/browser/migration-layer/script.js
@@ -3,7 +3,7 @@
 // This script will be browserified and prepended to the normal build
 // directly in window, not wrapped in any module definition
 // To avoid cases where we are loaded with /latest/ along with
-migrationLayer(process.env.ALGOLIA_BUILDNAME);
+migrationLayer(process && process.env.ALGOLIA_BUILDNAME);
 
 // Now onto the V2 related code:
 //  If the client is using /latest/$BUILDNAME.min.js, load V2 of the library

--- a/src/browser/migration-layer/script.js
+++ b/src/browser/migration-layer/script.js
@@ -3,7 +3,7 @@
 // This script will be browserified and prepended to the normal build
 // directly in window, not wrapped in any module definition
 // To avoid cases where we are loaded with /latest/ along with
-migrationLayer(process && process.env.ALGOLIA_BUILDNAME);
+migrationLayer(typeof process !== 'undefined' && process.env.ALGOLIA_BUILDNAME);
 
 // Now onto the V2 related code:
 //  If the client is using /latest/$BUILDNAME.min.js, load V2 of the library


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Most environments (webpack, browserify) by default define `process` as a shim for it.

However, some environements don't supply it, so we should always guard against it not being defined

fixes #691

(should be tested in a real angular app first)

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

guards around every use of `process`