### PR TITLE
feat(cache): cache the requests instead of responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     },
     {
       "path": "./dist/algoliasearch.?(jquery|parse).js",
-      "maxSize": "46 kB"
+      "maxSize": "46.5 kB"
     },
     {
       "path": "./dist/algoliasearch.angular.js",
-      "maxSize": "46.5 kB"
+      "maxSize": "47 kB"
     },
     {
       "path": "./dist/algoliasearchLite.min.js",

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -454,7 +454,12 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
   if (client._useCache && cache && cache[cacheID] !== undefined) {
     requestDebug('serving response from cache');
 
-    var promiseForCache = cache[cacheID];
+    var maybePromiseForCache = cache[cacheID];
+
+    // In case the cache is warmup with value that is not a promise
+    var promiseForCache = typeof maybePromiseForCache.then !== 'function'
+      ? Promise.resolve({responseText: maybePromiseForCache})
+      : maybePromiseForCache;
 
     return interopCallbackReturn(promiseForCache, function(content) {
       // In case of the cache request, return the original value

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -458,7 +458,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
 
     // In case the cache is warmup with value that is not a promise
     var promiseForCache = typeof maybePromiseForCache.then !== 'function'
-      ? Promise.resolve({responseText: maybePromiseForCache})
+      ? client._promise.resolve({responseText: maybePromiseForCache})
       : maybePromiseForCache;
 
     return interopCallbackReturn(promiseForCache, function(content) {

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -459,12 +459,12 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
 
 
   function interopCallbackReturn(request, callback) {
-    request.catch(function() {
-      // Release the cache on error
-      if (isCacheValidWithCurrentID(client._useRequestCache, cache, cacheID)) {
+    if (isCacheValidWithCurrentID(client._useRequestCache, cache, cacheID)) {
+      request.catch(function() {
+        // Release the cache on error
         delete cache[cacheID];
-      }
-    });
+      });
+    }
 
     // either we have a callback
     // either we are using promises

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -118,6 +118,7 @@ function AlgoliaSearchCore(applicationID, apiKey, opts) {
 
   this._ua = opts._ua;
   this._useCache = opts._useCache === undefined || opts._cache ? true : opts._useCache;
+  this._useRequestCache = this._useCache && opts._useRequestCache;
   this._useFallback = opts.useFallback === undefined ? true : opts.useFallback;
 
   this._setTimeout = opts._setTimeout;

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -425,8 +425,8 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     return client._useCache && cache && cache[cacheID] !== undefined;
   }
 
-  function interopCallbackReturn(promise, callback) {
-    promise.catch(function() {
+  function interopCallbackReturn(request, callback) {
+    request.catch(function() {
       // Release the cache on error
       if (isCacheValidWithCurrentID()) {
         delete cache[cacheID];
@@ -436,7 +436,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     // either we have a callback
     // either we are using promises
     if (typeof initialOpts.callback === 'function') {
-      promise.then(function okCb(content) {
+      request.then(function okCb(content) {
         exitPromise(function() {
           initialOpts.callback(null, callback(content));
         }, client._setTimeout || setTimeout);
@@ -446,7 +446,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         }, client._setTimeout || setTimeout);
       });
     } else {
-      return promise.then(function(content) {
+      return request.then(function(content) {
         return callback(content);
       });
     }
@@ -478,7 +478,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     });
   }
 
-  var promise = doRequest(
+  var request = doRequest(
     client._request, {
       url: initialOpts.url,
       method: initialOpts.method,
@@ -489,10 +489,10 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
   );
 
   if (client._useCache && cache) {
-    cache[cacheID] = promise;
+    cache[cacheID] = request;
   }
 
-  return interopCallbackReturn(promise, function(content) {
+  return interopCallbackReturn(request, function(content) {
     // In case of the first request, return the JSON value
     return content.body;
   });

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -236,7 +236,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     }
 
     // handle cache existence
-    if (client._useCache && !client._useRequestCache && cache && cache[cacheID] !== undefined) {
+    if (isCacheValidWithCurrentID(!client._useRequestCache, cache, cacheID)) {
       requestDebug('serving response from cache');
 
       // Cache response must match the type of the original one
@@ -444,19 +444,24 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     }
   }
 
-  function isCacheValidWithCurrentID() {
+  function isCacheValidWithCurrentID(
+    useRequestCache,
+    currentCache,
+    currentCacheID
+  ) {
     return (
       client._useCache &&
-      client._useRequestCache &&
-      cache &&
-      cache[cacheID] !== undefined
+      useRequestCache &&
+      currentCache &&
+      currentCache[currentCacheID] !== undefined
     );
   }
+
 
   function interopCallbackReturn(request, callback) {
     request.catch(function() {
       // Release the cache on error
-      if (isCacheValidWithCurrentID()) {
+      if (isCacheValidWithCurrentID(client._useRequestCache, cache, cacheID)) {
         delete cache[cacheID];
       }
     });
@@ -488,7 +493,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     cacheID += '_body_' + body;
   }
 
-  if (isCacheValidWithCurrentID()) {
+  if (isCacheValidWithCurrentID(client._useRequestCache, cache, cacheID)) {
     requestDebug('serving request from cache');
 
     var maybePromiseForCache = cache[cacheID];

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -466,9 +466,8 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
       });
     }
 
-    // either we have a callback
-    // either we are using promises
     if (typeof initialOpts.callback === 'function') {
+      // either we have a callback
       request.then(function okCb(content) {
         exitPromise(function() {
           initialOpts.callback(null, callback(content));
@@ -479,6 +478,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         }, client._setTimeout || setTimeout);
       });
     } else {
+      // either we are using promises
       return request.then(callback);
     }
   }

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -446,9 +446,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         }, client._setTimeout || setTimeout);
       });
     } else {
-      return request.then(function(content) {
-        return callback(content);
-      });
+      return request.then(callback);
     }
   }
 

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -445,7 +445,12 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
   }
 
   function isCacheValidWithCurrentID() {
-    return client._useCache && cache && cache[cacheID] !== undefined;
+    return (
+      client._useCache &&
+      client._useRequestCache &&
+      cache &&
+      cache[cacheID] !== undefined
+    );
   }
 
   function interopCallbackReturn(request, callback) {
@@ -473,18 +478,18 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     }
   }
 
-  if (client._useCache) {
+  if (client._useCache && client._useRequestCache) {
     cacheID = initialOpts.url;
   }
 
   // as we sometime use POST requests to pass parameters (like query='aa'),
   // the cacheID must also include the body to be different between calls
-  if (client._useCache && body) {
+  if (client._useCache && client._useRequestCache && body) {
     cacheID += '_body_' + body;
   }
 
   if (isCacheValidWithCurrentID()) {
-    requestDebug('serving response from cache');
+    requestDebug('serving request from cache');
 
     var maybePromiseForCache = cache[cacheID];
 
@@ -509,7 +514,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     }
   );
 
-  if (client._useCache && cache) {
+  if (client._useCache && client._useRequestCache && cache) {
     cache[cacheID] = request;
   }
 

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -239,8 +239,13 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     if (isCacheValidWithCurrentID(!client._useRequestCache, cache, cacheID)) {
       requestDebug('serving response from cache');
 
+      var responseText = cache[cacheID];
+
       // Cache response must match the type of the original one
-      return client._promise.resolve({body: JSON.parse(cache[cacheID])});
+      return client._promise.resolve({
+        body: JSON.parse(responseText),
+        responseText: responseText
+      });
     }
 
     // if we reached max tries

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -421,7 +421,18 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     }
   }
 
+  function isCacheValidWithCurrentID() {
+    return client._useCache && cache && cache[cacheID] !== undefined;
+  }
+
   function interopCallbackReturn(promise, callback) {
+    promise.catch(function() {
+      // Release the cache on error
+      if (isCacheValidWithCurrentID()) {
+        delete cache[cacheID];
+      }
+    });
+
     // either we have a callback
     // either we are using promises
     if (typeof initialOpts.callback === 'function') {
@@ -451,7 +462,7 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
     cacheID += '_body_' + body;
   }
 
-  if (client._useCache && cache && cache[cacheID] !== undefined) {
+  if (isCacheValidWithCurrentID()) {
     requestDebug('serving response from cache');
 
     var maybePromiseForCache = cache[cacheID];

--- a/src/browser/jsonp-request.js
+++ b/src/browser/jsonp-request.js
@@ -36,7 +36,8 @@ function jsonpRequest(url, opts, cb) {
     clean();
 
     cb(null, {
-      body: data/* ,
+      body: data,
+      responseText: JSON.stringify(data)/* ,
       // We do not send the statusCode, there's no statusCode in JSONP, it will be
       // computed using data.status && data.message like with XDR
       statusCode*/

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -191,6 +191,7 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
         try {
           out = {
             body: JSON.parse(data),
+            responseText: data,
             statusCode: statusCode,
             headers: headers
           };

--- a/src/server/builds/parse.js
+++ b/src/server/builds/parse.js
@@ -86,6 +86,7 @@ AlgoliaSearchParse.prototype._request = function(rawUrl, opts) {
     promise.resolve({
       statusCode: res.status,
       body: res.data,
+      responseText: res.text,
       headers: res.headers
     });
   }

--- a/test/spec/common/client/cache-request.js
+++ b/test/spec/common/client/cache-request.js
@@ -2,7 +2,7 @@
 
 var test = require('tape');
 
-test('expect to cache the requests', function(t) {
+test('expect to cache the request', function(t) {
   t.plan(2);
 
   var fauxJax = require('faux-jax');
@@ -12,6 +12,7 @@ test('expect to cache the requests', function(t) {
   var client = fixture.client;
 
   client._useCache = true;
+  client._useRequestCache = true;
 
   fauxJax.install({gzip: true});
 
@@ -54,6 +55,7 @@ test('expect to always return the original response', function(t) {
   var client = fixture.client;
 
   client._useCache = true;
+  client._useRequestCache = true;
 
   fauxJax.install({gzip: true});
 
@@ -93,6 +95,7 @@ test('expect to release the cache in case of error', function(t) {
   var client = fixture.client;
 
   client._useCache = true;
+  client._useRequestCache = true;
 
   fauxJax.install({gzip: true});
 

--- a/test/spec/common/client/cache-response.js
+++ b/test/spec/common/client/cache-response.js
@@ -1,0 +1,143 @@
+'use strict';
+
+var test = require('tape');
+
+test('expect to cache the response', function(t) {
+  t.plan(4);
+
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
+
+  client._useCache = true;
+
+  fauxJax.install({gzip: true});
+
+  var count = 0;
+  fauxJax.on('request', function(req) {
+    count++;
+    req.respond(200, {}, '{}');
+  });
+
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
+
+  Promise.all([
+    search(),
+    search(),
+    search()
+  ]).then(function() {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 3);
+    t.equal(cacheLength, 1);
+
+    return Promise.all([
+      search(),
+      search(),
+      search()
+    ]);
+  }).then(function() {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 3);
+    t.equal(cacheLength, 1);
+
+    fauxJax.restore();
+  });
+});
+
+test('expect to always return the original response', function(t) {
+  t.plan(2);
+
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
+
+  client._useCache = true;
+
+  fauxJax.install({gzip: true});
+
+  fauxJax.on('request', function(req) {
+    req.respond(200, {}, '{"hits": []}');
+  });
+
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
+
+  search().then(function(content) {
+    t.deepEqual(content, {hits: []});
+
+    content.__shouldNotBePresentOnNextResolution = true;
+
+    return search();
+  }).then(function(content) {
+    t.deepEqual(content, {hits: []});
+
+    fauxJax.restore();
+  });
+});
+
+test('expect to release the cache in case of error', function(t) {
+  t.plan(6);
+
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
+
+  client._useCache = true;
+
+  fauxJax.install({gzip: true});
+
+  let count = 0;
+  // Avoid retry logic with unparsable JSON
+  fauxJax.on('request', function(req) {
+    count++;
+    req.respond(500, {}, '');
+  });
+
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
+
+  search().catch(function(err) {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 1);
+    t.equal(cacheLength, 0);
+    t.equal(err.name, 'AlgoliaSearchUnparsableJSONError');
+
+    return search();
+  }).catch(function(err) {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 2);
+    t.equal(cacheLength, 0);
+    t.equal(err.name, 'AlgoliaSearchUnparsableJSONError');
+
+    fauxJax.restore();
+  });
+});

--- a/test/spec/common/client/cache.js
+++ b/test/spec/common/client/cache.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var test = require('tape');
+
+test('expect to cache the requests', function(t) {
+  t.plan(2);
+
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
+
+  client._useCache = true;
+
+  fauxJax.install({gzip: true});
+
+  var count = 0;
+  fauxJax.on('request', function(req) {
+    count++;
+    req.respond(200, {}, '{}');
+  });
+
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
+
+  Promise.all([
+    search(),
+    search(),
+    search()
+  ]).then(function() {
+    var cacheID = Object.keys(client.cache)[0];
+
+    t.equal(count, 1);
+    t.equal(
+      cacheID,
+      '/1/indexes/*/queries_body_{"requests":[{"indexName":"'
+      + credentials.indexName
+      + '","params":"query=Hello"}]}'
+    );
+
+    fauxJax.restore();
+  });
+});
+
+// @TODO: enable this test when we are able to mock `responseText`
+// test('expect to always return the original response', function(t) {
+//   t.plan(2);
+
+//   var fauxJax = require('faux-jax');
+//   var createFixture = require('../../../utils/create-fixture');
+//   var fixture = createFixture();
+//   var credentials = fixture.credentials;
+//   var client = fixture.client;
+
+//   client._useCache = true;
+
+//   fauxJax.install({gzip: true});
+
+//   var count = 0;
+//   fauxJax.on('request', function(req) {
+//     count++;
+//     req.respond(200, {}, '{"hits": []}');
+//   });
+
+//   function search() {
+//     return client.search([
+//       {
+//         indexName: credentials.indexName,
+//         query: 'Hello'
+//       }
+//     ]);
+//   }
+
+//   search().then(function(content) {
+//     t.deepEqual(content, {hits: []});
+
+//     content.__shouldNotBePresentOnNextResolution = true;
+
+//     return search();
+//   }).then(function(content) {
+//     t.deepEqual(content, {hits: []});
+
+//     fauxJax.restore();
+//   });
+// });

--- a/test/spec/common/client/cache.js
+++ b/test/spec/common/client/cache.js
@@ -35,15 +35,10 @@ test('expect to cache the requests', function(t) {
     search(),
     search()
   ]).then(function() {
-    var cacheID = Object.keys(client.cache)[0];
+    var cacheLength = Object.keys(client.cache).length;
 
     t.equal(count, 1);
-    t.equal(
-      cacheID,
-      '/1/indexes/*/queries_body_{"requests":[{"indexName":"'
-      + credentials.indexName
-      + '","params":"query=Hello"}]}'
-    );
+    t.equal(cacheLength, 1);
 
     fauxJax.restore();
   });

--- a/test/spec/common/client/cache.js
+++ b/test/spec/common/client/cache.js
@@ -44,44 +44,41 @@ test('expect to cache the requests', function(t) {
   });
 });
 
-// @TODO: enable this test when we are able to mock `responseText`
-// test('expect to always return the original response', function(t) {
-//   t.plan(2);
+test('expect to always return the original response', function(t) {
+  t.plan(2);
 
-//   var fauxJax = require('faux-jax');
-//   var createFixture = require('../../../utils/create-fixture');
-//   var fixture = createFixture();
-//   var credentials = fixture.credentials;
-//   var client = fixture.client;
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
 
-//   client._useCache = true;
+  client._useCache = true;
 
-//   fauxJax.install({gzip: true});
+  fauxJax.install({gzip: true});
 
-//   var count = 0;
-//   fauxJax.on('request', function(req) {
-//     count++;
-//     req.respond(200, {}, '{"hits": []}');
-//   });
+  fauxJax.on('request', function(req) {
+    req.respond(200, {}, '{"hits": []}');
+  });
 
-//   function search() {
-//     return client.search([
-//       {
-//         indexName: credentials.indexName,
-//         query: 'Hello'
-//       }
-//     ]);
-//   }
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
 
-//   search().then(function(content) {
-//     t.deepEqual(content, {hits: []});
+  search().then(function(content) {
+    t.deepEqual(content, {hits: []});
 
-//     content.__shouldNotBePresentOnNextResolution = true;
+    content.__shouldNotBePresentOnNextResolution = true;
 
-//     return search();
-//   }).then(function(content) {
-//     t.deepEqual(content, {hits: []});
+    return search();
+  }).then(function(content) {
+    t.deepEqual(content, {hits: []});
 
-//     fauxJax.restore();
-//   });
-// });
+    fauxJax.restore();
+  });
+});

--- a/test/spec/common/client/cache.js
+++ b/test/spec/common/client/cache.js
@@ -82,3 +82,51 @@ test('expect to always return the original response', function(t) {
     fauxJax.restore();
   });
 });
+
+test('expect to release the cache in case of error', function(t) {
+  t.plan(6);
+
+  var fauxJax = require('faux-jax');
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var credentials = fixture.credentials;
+  var client = fixture.client;
+
+  client._useCache = true;
+
+  fauxJax.install({gzip: true});
+
+  let count = 0;
+  // Avoid retry logic with unparsable JSON
+  fauxJax.on('request', function(req) {
+    count++;
+    req.respond(500, {}, '');
+  });
+
+  function search() {
+    return client.search([
+      {
+        indexName: credentials.indexName,
+        query: 'Hello'
+      }
+    ]);
+  }
+
+  search().catch(function(err) {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 1);
+    t.equal(cacheLength, 0);
+    t.equal(err.name, 'AlgoliaSearchUnparsableJSONError');
+
+    return search();
+  }).catch(function(err) {
+    var cacheLength = Object.keys(client.cache).length;
+
+    t.equal(count, 2);
+    t.equal(cacheLength, 0);
+    t.equal(err.name, 'AlgoliaSearchUnparsableJSONError');
+
+    fauxJax.restore();
+  });
+});


### PR DESCRIPTION
**Summary**

This PR update the strategy for caching the requests. With the current implementation we cache the results when we receive the response. It means that when we perform multiple exact same requests in parallel the client will trigger multiple network requests. 

This PR introduce a different approach, we cache the promise of the requests. Now when multiple exact same requests are triggered in parallel the same promise is reused for all the requests. Only one network call can be trigger for a request.

List of the changes:

- add the `responseText` property to each `_request` implementation. The `jsonRequest` method now return an object with `{ body, responseText }` to properly resolve the cached value. It brings consistency in the `jsonRequest` response, we can now safely use both of the attributes.
- update the `jsonRequest` method to cache the result of `doRequest` instead of caching the raw response
- **EDIT**: enable the caching of request behind an option `_useRequestCache`. By default this option is `false` in that case the behaviour is the same as today. The user can choose to enable this option with `_useRequestCache: true`.

Questions:

- I didn't found a way to test the different builds. The PR adds the `responseText` to each of the implementation but I don't know how to test that the `_request` method correctly return the response.
- Some implementation might rely on the `cache` attribute of the client. We don't document it but it's still accessible on the client instance. The type of the value cached change from string to a promise. ~~To avoid a BC we can introduce an option for handle different caching strategy with the default value on the previous implementation.~~
- We do clear the cache in case of error now. ~Last but not least since we cache the results of `doRequest` we also cache the error when the retry strategy fails. It means that on subsequent requests the error will be fetch from the cache instead of doing a new call. We can avoid this issue by clearing the cache in case of error, but it's **not implemented** in this PR.~

**Before**

![before](https://user-images.githubusercontent.com/6513513/40587195-375a8d82-61cc-11e8-945d-7cc7c3c3bb94.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/40587197-3b9d16d0-61cc-11e8-8551-e9d1c10d4ae2.gif)
