### PR TITLE
fix(parse): correct path to debug module

### DIFF
--- a/scripts/parse-build.webpack.config.js
+++ b/scripts/parse-build.webpack.config.js
@@ -12,9 +12,8 @@ module.exports = {
   target: 'node',
   resolve: {
     alias: {
-      debug: 'debug/browser.js',
-      inherits: 'inherits/inherits_browser.js',
-      'util-deprecate': 'util-deprecate/browser.js'
+      debug: 'debug/src/browser.js',
+      inherits: 'inherits/inherits_browser.js'
     }
   }
 };


### PR DESCRIPTION
fixes parse build, weirdly webpack is not throwing when importing an
unkown module using target node