### PR TITLE
test(bundlesize): run build before testing size

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "examples": "http-server . -a 0.0.0.0",
     "watch": "watchify index.js -d -v -s algoliasearch -o dist/algoliasearch.js",
     "release": "git clean dist/ -f && git checkout dist/ && yarn && ./scripts/release && APP_ENV=production npm run build",
-    "test": "./scripts/test-node-unit && ./scripts/lint",
+    "test": "./scripts/test",
     "test-ci:lint": "./scripts/lint",
-    "test-ci:bundlesize": "bundlesize",
+    "test-ci:bundlesize": "./scripts/bundlesize",
     "test-ci:unit-node": "./scripts/test-node-unit",
     "test-ci:integration-node": "./scripts/test-node-integration",
     "test-ci:unit-browsers": "./scripts/test-browser unit",
@@ -48,7 +48,7 @@
     },
     {
       "path": "./dist/algoliasearchLite.js",
-      "maxSize": "32 kB"
+      "maxSize": "32.5 kB"
     }
   ],
   "repository": {

--- a/scripts/bundlesize
+++ b/scripts/bundlesize
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e # exit when error
+
+echo "Bundle size"
+
+echo "Bundle size: build"
+NODE_ENV=production npm run build
+
+echo "Bundle size: sizing"
+bundlesize

--- a/scripts/test
+++ b/scripts/test
@@ -4,8 +4,8 @@ set -e # exit when error
 
 echo "Test"
 
-echo "Test: node"
-./scripts/test-node
+echo "Test: node (unit)"
+./scripts/test-node-unit
 
 echo "Test: lint"
 ./scripts/lint


### PR DESCRIPTION
**summary**
The reason is pretty simple: since we track the `dist` in GitHub, if we don't do a build before testing the build size; we are actually testing the size of the previous build, rather than the current build.

Also I realised that the `yarn test` command was not updated with previous test name changes, so did that.

The bundlesize had to be increased for the lite build, since #694 increased that size over the limit.

**results**

* fixed bundlesize tests
* fixed `yarn test`
* increased size allowance