### PR TITLE
docs(do): more relevant error message on bad objectID type

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -223,7 +223,11 @@ Index.prototype.saveObjects = function(objects, callback) {
 */
 Index.prototype.deleteObject = function(objectID, callback) {
   if (typeof objectID === 'function' || typeof objectID !== 'string' && typeof objectID !== 'number') {
-    var err = new errors.AlgoliaSearchError('Cannot delete an object without an objectID');
+    var err = new errors.AlgoliaSearchError(
+      objectID && typeof objectID !== 'function'
+      ? 'ObjectID must be a string'
+      : 'Cannot delete an object without an objectID'
+    );
     callback = objectID;
     if (typeof callback === 'function') {
       return callback(err);

--- a/test/spec/common/index/deleteObject.js
+++ b/test/spec/common/index/deleteObject.js
@@ -33,3 +33,21 @@ test('deleteObject(cb)  without an objectID, with a cb', function(t) {
     );
   });
 });
+
+
+test('deleteObject(cb)  with bad type objectID', function(t) {
+  t.plan(2);
+  var bind = require('lodash-compat/function/bind');
+
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  index.deleteObject([]).then(bind(t.fail, t), function(err) {
+    t.ok(err instanceof Error, 'received an error');
+    t.equal(
+      err.message,
+      'ObjectID must be a string'
+    );
+  });
+});


### PR DESCRIPTION
**Summary**
When sending a bad objectID type, the error message is not very clear, e.g. if you send a Buffer instead of String by mistake it make you think that you send a null objectID whereas this is not the case.

**Result**

If sending a null objectID error message is 'Cannot delete an object without an objectID' and if sending a bad type objectID message is  'ObjectID must be a string'