### PR TITLE
fix(search): add opts.strategy to request object

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -662,7 +662,7 @@ AlgoliaSearchCore.prototype.search = function(queries, opts, callback) {
   var url = '/1/indexes/*/queries';
 
   if (opts.strategy !== undefined) {
-    url += '?strategy=' + opts.strategy;
+    postObj.strategy = opts.strategy;
   }
 
   return this._jsonRequest({

--- a/test/spec/common/client/test-cases/search.js
+++ b/test/spec/common/client/test-cases/search.js
@@ -73,12 +73,13 @@ module.exports = [{
   action: 'read',
   expectedRequest: {
     method: 'POST',
-    URL: {pathname: '/1/indexes/*/queries', query: {strategy: 'none'}},
+    URL: {pathname: '/1/indexes/*/queries'},
     body: {
       requests: [{
         indexName: 'yaaaaaw',
         params: 'hitsPerSmurf=9'
-      }]
+      }],
+      strategy: 'none'
     }
   }
 }];


### PR DESCRIPTION

fixes #719

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Up until now this was added to the URL query parameters, but according to the [docs](https://www.algolia.com/doc/rest-api/search#method-param-strategy), this is a parameter in the body. Because of this, the strategy cannot work in JSONP anymore, but it also seems to never have worked in the first place, so I'm not too concerned about that.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

moved `opts.strategy` to the request body from the URL