### PR TITLE
chore(core): deprecate similarSearch

### DIFF
--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -132,7 +132,13 @@ IndexCore.prototype.search = buildSearchMethod('query');
 *   All search parameters are supported (see search function), restrictSearchableAttributes and facetFilters
 *   are the two most useful to restrict the similar results and get more relevant content
 */
-IndexCore.prototype.similarSearch = buildSearchMethod('similarQuery');
+IndexCore.prototype.similarSearch = deprecated(
+  buildSearchMethod('similarQuery'),
+  deprecatedMessage(
+    'index.similarSearch(query[, callback])',
+    'index.search({ similarQuery: query }[, callback])'
+  )
+);
 
 /*
 * Browse index content. The response content will have a `cursor` property that you can use

--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -132,7 +132,7 @@ IndexCore.prototype.search = buildSearchMethod('query');
 *   All search parameters are supported (see search function), restrictSearchableAttributes and facetFilters
 *   are the two most useful to restrict the similar results and get more relevant content
 */
-IndexCore.prototype.similarSearch = deprecated(
+IndexCore.prototype.similarSearch = deprecate(
   buildSearchMethod('similarQuery'),
   deprecatedMessage(
     'index.similarSearch(query[, callback])',


### PR DESCRIPTION
fixes https://github.com/algolia/algoliasearch-client-javascript/issues/610

This is documented nowhere and is beta, has an alternative with "similarQuery" search param

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

similarSearch isn't necessary

wiki link is: https://github.com/algolia/algoliasearch-client-javascript/wiki/Deprecated#indexsimilarsearchquery-callback

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

the method is now deprecated, so it can be removed more safely
