### PR TITLE
Add copy* and replaceAll* methods

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -85,6 +85,18 @@ AlgoliaSearch.prototype.copyIndex = function(srcIndexName, dstIndexName, scopeOr
   });
 };
 
+AlgoliaSearch.prototype.copySettings = function(srcIndexName, dstIndexName, callback) {
+  return this.copyIndex(srcIndexName, dstIndexName, ['settings'], callback);
+};
+
+AlgoliaSearch.prototype.copySynonyms = function(srcIndexName, dstIndexName, callback) {
+  return this.copyIndex(srcIndexName, dstIndexName, ['synonyms'], callback);
+};
+
+AlgoliaSearch.prototype.copyRules = function(srcIndexName, dstIndexName, callback) {
+  return this.copyIndex(srcIndexName, dstIndexName, ['rules'], callback);
+};
+
 /**
  * Return last log entries.
  * @param offset Specify the first entry to retrieve (0-based, 0 is the most recent log entry).

--- a/src/Index.js
+++ b/src/Index.js
@@ -783,6 +783,18 @@ Index.prototype.batchSynonyms = function(synonyms, opts, callback) {
   });
 };
 
+Index.prototype.replaceAllSynonyms = function(synonyms, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  } else if (opts === undefined) {
+    opts = {};
+  }
+  opts.replaceExistingSynonyms = true;
+
+  return this.batchSynonyms(synonyms, opts, callback);
+};
+
 Index.prototype.searchRules = function(params, callback) {
   if (typeof params === 'function') {
     callback = params;
@@ -899,6 +911,18 @@ Index.prototype.batchRules = function(rules, opts, callback) {
     body: rules,
     callback: callback
   });
+};
+
+Index.prototype.replaceAllRules = function(rules, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  } else if (opts === undefined) {
+    opts = {};
+  }
+  opts.clearExistingRules = true;
+
+  return this.batchSynonyms(rules, opts, callback);
 };
 
 /*

--- a/src/Index.js
+++ b/src/Index.js
@@ -213,6 +213,35 @@ Index.prototype.saveObjects = function(objects, callback) {
   });
 };
 
+Index.prototype.replaceAllObjects = function(objects, opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  } else if (opts === undefined) {
+    opts = {};
+  }
+
+  var safe = opts.safe || false;
+  var tmpIndexName = this.indexName + '_' + Math.random() + '_tmp';
+
+  var copyResponse = this.as.copyIndex(this.indexName, tmpIndexName, ['settings', 'rules', 'synonyms']);
+  if (safe) {
+    this.waitTask(copyResponse.taskID);
+  }
+
+  var saveResponse = this.saveObjects(objects);
+  if (safe) {
+    this.waitTask(saveResponse.taskID);
+  }
+
+  var moveResponse = this.as.moveIndex(tmpIndexName, this.indexName);
+  if (safe) {
+    this.waitTask(moveResponse.taskID);
+  }
+
+  return [copyResponse, saveResponse, moveResponse];
+};
+
 /*
 * Delete an object from the index
 *


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The new PHP api client will introduce new method to easily replace all objects/synonyms/rules and copy settings/synonyms/rules. We decided to back port these helpers to current API client version.

**Result**

I'm working on the tests for `replaceAllObjects`, the other methods are basically aliasing already existing methods.
