### PR TITLE
Remove dependency isarray

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "foreach": "^2.0.5",
     "global": "^4.3.2",
     "inherits": "^2.0.1",
-    "isarray": "^2.0.1",
     "load-script": "^1.0.0",
     "object-keys": "^1.0.11",
     "querystring-es3": "^0.2.1",

--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -290,10 +290,9 @@ AlgoliaSearch.prototype.addUserKey = deprecate(function(acls, params, callback) 
  * @see {@link https://www.algolia.com/doc/rest_api#AddKey|Algolia REST API Documentation}
  */
 AlgoliaSearch.prototype.addApiKey = function(acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.addApiKey(arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -381,10 +380,9 @@ AlgoliaSearch.prototype.updateUserKey = deprecate(function(key, acls, params, ca
  * @see {@link https://www.algolia.com/doc/rest_api#UpdateIndexKey|Algolia REST API Documentation}
  */
 AlgoliaSearch.prototype.updateApiKey = function(key, acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.updateApiKey(key, arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -482,10 +480,9 @@ AlgoliaSearch.prototype.sendQueriesBatch = deprecate(function sendQueriesBatchDe
  * }], cb)
  */
 AlgoliaSearch.prototype.batch = function(operations, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: client.batch(operations[, callback])';
 
-  if (!isArray(operations)) {
+  if (!Array.isArray(operations)) {
     throw new Error(usage);
   }
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -57,10 +57,9 @@ Index.prototype.addObject = function(content, objectID, callback) {
 *  content: the server answer that updateAt and taskID
 */
 Index.prototype.addObjects = function(objects, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.addObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -129,10 +128,9 @@ Index.prototype.partialUpdateObjects = function(objects, createIfNotExists, call
     createIfNotExists = true;
   }
 
-  var isArray = require('isarray');
   var usage = 'Usage: index.partialUpdateObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -185,10 +183,9 @@ Index.prototype.saveObject = function(object, callback) {
 *  content: the server answer that updateAt and taskID
 */
 Index.prototype.saveObjects = function(objects, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.saveObjects(arrayOfObjects[, callback])';
 
-  if (!isArray(objects)) {
+  if (!Array.isArray(objects)) {
     throw new Error(usage);
   }
 
@@ -254,12 +251,11 @@ Index.prototype.deleteObject = function(objectID, callback) {
 *  content: the server answer that contains 3 elements: createAt, taskId and objectID
 */
 Index.prototype.deleteObjects = function(objectIDs, callback) {
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: index.deleteObjects(arrayOfObjectIDs[, callback])';
 
-  if (!isArray(objectIDs)) {
+  if (!Array.isArray(objectIDs)) {
     throw new Error(usage);
   }
 
@@ -1119,10 +1115,9 @@ Index.prototype.addUserKey = deprecate(function(acls, params, callback) {
 * @deprecated see client.addApiKey()
 */
 Index.prototype.addApiKey = deprecate(function(acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.addApiKey(arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 
@@ -1210,10 +1205,9 @@ Index.prototype.updateUserKey = deprecate(function(key, acls, params, callback) 
 * @deprecated see client.updateApiKey()
 */
 Index.prototype.updateApiKey = deprecate(function(key, acls, params, callback) {
-  var isArray = require('isarray');
   var usage = 'Usage: index.updateApiKey(key, arrayOfAcls[, params, callback])';
 
-  if (!isArray(acls)) {
+  if (!Array.isArray(acls)) {
     throw new Error(usage);
   }
 

--- a/src/IndexCore.js
+++ b/src/IndexCore.js
@@ -337,12 +337,11 @@ IndexCore.prototype.getObject = function(objectID, attrs, callback) {
 * @param objectIDs the array of unique identifier of objects to retrieve
 */
 IndexCore.prototype.getObjects = function(objectIDs, attributesToRetrieve, callback) {
-  var isArray = require('isarray');
   var map = require('./map.js');
 
   var usage = 'Usage: index.getObjects(arrayOfObjectIDs[, callback])';
 
-  if (!isArray(objectIDs)) {
+  if (!Array.isArray(objectIDs)) {
     throw new Error(usage);
   }
 


### PR DESCRIPTION

**Summary**

There is no more need for `isarray`

**Result**

No logical change...just drop support for IE8