### PR TITLE
Fix a small typo in the error message

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -57,7 +57,7 @@ module.exports = {
   ),
   RequestTimeout: createCustomError(
     'RequestTimeout',
-    'Request timedout before getting a response'
+    'Request timed out before getting a response'
   ),
   Network: createCustomError(
     'Network',


### PR DESCRIPTION
I'm not sure what's best between timed out or timeout. I have noticed it in https://sentry.io/share/issue/ed7798be9e8a4db28f21ec9eb8f49229/.