### PR TITLE
fix(ua): add space between added agent

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -171,8 +171,10 @@ AlgoliaSearchCore.prototype.unsetExtraHeader = function(name) {
 * @param algoliaAgent the agent to add
 */
 AlgoliaSearchCore.prototype.addAlgoliaAgent = function(algoliaAgent) {
-  if (this._ua.indexOf(';' + algoliaAgent) === -1) {
-    this._ua += ';' + algoliaAgent;
+  var algoliaAgentWithDelimiter = '; ' + algoliaAgent;
+
+  if (this._ua.indexOf(algoliaAgentWithDelimiter) === -1) {
+    this._ua += algoliaAgentWithDelimiter;
   }
 };
 
@@ -568,7 +570,7 @@ AlgoliaSearchCore.prototype._computeRequestHeaders = function(options) {
   var forEach = require('foreach');
 
   var ua = options.additionalUA ?
-    this._ua + ';' + options.additionalUA :
+    this._ua + '; ' + options.additionalUA :
     this._ua;
 
   var requestHeaders = {

--- a/test/spec/common/client/addAlgoliaAgent.js
+++ b/test/spec/common/client/addAlgoliaAgent.js
@@ -24,7 +24,9 @@ test('AddAlgoliaAgent and custom search-time agent with x-algolia-agent', functi
     additionalUA: 'the other agent'
   });
 
-  var expectedAgent = fixture.algoliasearch.ua + ';And some other incredible agent;the other agent';
+  var expectedAgent =
+    fixture.algoliasearch.ua +
+    '; And some other incredible agent; the other agent';
 
   fauxJax.once('request', function(req) {
     var agent = process.browser ?


### PR DESCRIPTION
The PR adds space between added agent.

**Before**

```
Algolia [...] (3.32.1);mySuperAlgoliaAgent;mySuperAlgoliaAgent with spaces
```

**After**

```
Algolia [...] (3.32.1); mySuperAlgoliaAgent; mySuperAlgoliaAgent with spaces
```