### PR TITLE
feat(api-keys): adds restore api key method

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -245,6 +245,27 @@ AlgoliaSearch.prototype.deleteApiKey = function(key, callback) {
   });
 };
 
+/**
+ * Restore a deleted API key
+ *
+ * @param {String} key - The key to restore
+ * @param {Function} callback - The result callback called with two arguments
+ *   error: null or Error('message')
+ *   content: the server answer with the restored API key
+ * @return {Promise|undefined} Returns a promise if no callback given
+ * @example
+ * client.restoreApiKey('APIKEY')
+ * @see {@link https://www.algolia.com/doc/rest-api/search/#restore-api-key|Algolia REST API Documentation}
+ */
+AlgoliaSearch.prototype.restoreApiKey = function(key, callback) {
+  return this._jsonRequest({
+    method: 'POST',
+    url: '/1/keys/' + key + '/restore',
+    hostType: 'write',
+    callback: callback
+  });
+};
+
 /*
  @deprecated see client.addApiKey
  */

--- a/test/spec/common/client/interface.js
+++ b/test/spec/common/client/interface.js
@@ -48,6 +48,7 @@ test('AlgoliaSearch client API spec', function(t) {
     'listUserKeys',
     'moveIndex',
     'removeUserID',
+    'restoreApiKey',
     'search',
     'searchForFacetValues',
     'searchUserIDs',

--- a/test/spec/common/client/test-cases/restoreApiKey.js
+++ b/test/spec/common/client/test-cases/restoreApiKey.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var fauxJax = require('faux-jax');
+
+if (!process.browser || fauxJax.support.xhr.cors) {
+  module.exports = [{
+    testName: 'client.restoreApiKey(key, cb)',
+    object: 'client',
+    methodName: 'restoreApiKey',
+    callArguments: ['mykey'],
+    action: 'write',
+    expectedRequest: {
+      method: 'POST',
+      URL: {pathname: '/1/keys/mykey/restore'}
+    }
+  }];
+}


### PR DESCRIPTION
This pull request introduces the `client.restoreApiKey` method as specified common api client specs.

This new method allows to restore a deleted API key, along with its associated rights.

Usage:
```js
var client = algoliasearch('.', '.');

client.restoreApiKey('APIKEY');
```

Fixes #742 