### PR TITLE
feat(index): implement index.exists method

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -901,6 +901,28 @@ Index.prototype.batchRules = function(rules, opts, callback) {
   });
 };
 
+Index.prototype.exists = function(callback) {
+  var result = this.getSettings().then(function() {
+    return true;
+  }).catch(function(err) {
+    if (err instanceof errors.AlgoliaSearchError && err.statusCode === 404) {
+      return false;
+    }
+
+    throw err;
+  });
+
+  if (typeof callback !== 'function') {
+    return result;
+  }
+
+  result.then(function(res) {
+    callback(null, res);
+  }).catch(function(err) {
+    callback(err);
+  });
+};
+
 /*
 * Set settings for this index
 *

--- a/test/spec/common/index/exists.js
+++ b/test/spec/common/index/exists.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var test = require('tape');
+
+test('index.exists()', function(t) {
+  indexDoesNotExist('callback', t);
+  indexDoesNotExist('promise', t);
+  indexExists('callback', t);
+  indexExists('promise', t);
+});
+
+function indexDoesNotExist(asyncMode, mainTest) {
+  mainTest.test('unexisting index using a ' + asyncMode, function(t) {
+    t.plan(1);
+
+    var bind = require('lodash-compat/function/bind');
+    var fauxJax = require('faux-jax');
+
+    var createFixture = require('../../../utils/create-fixture');
+    var fixture = createFixture();
+    var index = fixture.index;
+
+    fauxJax.install();
+    fauxJax.once('request', respondToGetSettings);
+
+    if (asyncMode === 'callback') {
+      index.exists(function(err, response) {
+        if (err) {
+          t.error(err);
+        }
+        t.notOk(response);
+        fauxJax.restore();
+      });
+    } else if (asyncMode === 'promise') {
+      index
+        .exists()
+        .then(function(response) {
+          t.notOk(response);
+          fauxJax.restore();
+        }, bind(t.fail, t));
+    }
+
+    function respondToGetSettings(req) {
+      req.respond(
+        404,
+        {},
+        JSON.stringify({
+          name: 'AlgoliaSearchError',
+          message: 'Index does not exist'
+        })
+      );
+    }
+  });
+}
+
+function indexExists(asyncMode, mainTest) {
+  mainTest.test('existing index using a ' + asyncMode, function(t) {
+    t.plan(1);
+
+    var bind = require('lodash-compat/function/bind');
+    var fauxJax = require('faux-jax');
+
+    var createFixture = require('../../../utils/create-fixture');
+    var fixture = createFixture();
+    var index = fixture.index;
+
+    fauxJax.install();
+    fauxJax.once('request', respondToGetSettings);
+
+    if (asyncMode === 'callback') {
+      index.exists(function(err, response) {
+        if (err) {
+          t.error(err);
+        }
+        t.ok(response);
+        fauxJax.restore();
+      });
+    } else if (asyncMode === 'promise') {
+      index
+        .exists()
+        .then(function(response) {
+          t.ok(response);
+          fauxJax.restore();
+        }, bind(t.fail, t));
+    }
+
+    function respondToGetSettings(req) {
+      req.respond(
+        200,
+        {},
+        JSON.stringify({
+          attributesForFaceting: ['searchable(category)']
+        })
+      );
+    }
+  });
+}

--- a/test/spec/common/index/interface.js
+++ b/test/spec/common/index/interface.js
@@ -42,6 +42,7 @@ test('AlgoliaSearch index API spec', function(t) {
     'deleteRule',
     'deleteApiKey',
     'deleteUserKey',
+    'exists',
     'exportSynonyms',
     'exportRules',
     'getObject',


### PR DESCRIPTION
Added a method to check if the index exists

**Summary**

This is self-explanatory. It adds a method on the index to check if it exists or not. You can check the specification here https://github.com/algolia/algoliasearch-client-javascript/issues/768

**Results**

You can either call `index.exists.then( ... )` or `index.exists(function(err, content) { ... });`. It will return `true` if the index exists and `false` if we get a 404 AlgoliaSearchError. Any other errors is thrown.