### PR TITLE
feat: remaining-validity

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -732,6 +732,7 @@ AlgoliaSearch.prototype.disableRateLimitForward = notImplemented;
 AlgoliaSearch.prototype.useSecuredAPIKey = notImplemented;
 AlgoliaSearch.prototype.disableSecuredAPIKey = notImplemented;
 AlgoliaSearch.prototype.generateSecuredApiKey = notImplemented;
+AlgoliaSearch.prototype.getSecuredApiKeyRemainingValidity = notImplemented;
 
 function notImplemented() {
   var message = 'Not implemented in this environment.\n' +

--- a/src/errors.js
+++ b/src/errors.js
@@ -67,6 +67,10 @@ module.exports = {
     'JSONPScriptFail',
     '<script> was loaded but did not call our provided callback'
   ),
+  ValidUntilNotFound: createCustomError(
+    'ValidUntilNotFound',
+    'The SecuredAPIKey does not have a validUntil parameter.'
+  ),
   JSONPScriptError: createCustomError(
     'JSONPScriptError',
     '<script> unable to load due to an `error` event on it'

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -320,3 +320,21 @@ AlgoliaSearchNodeJS.prototype.generateSecuredApiKey = function generateSecuredAp
 
   return new Buffer(securedKey + searchParams).toString('base64');
 };
+
+AlgoliaSearchNodeJS.prototype.getSecuredApiKeyRemainingValidity = function getSecuredApiKeyRemainingValidity(
+  securedAPIKey,
+) {
+  var decodedString = new Buffer(securedAPIKey, 'base64').toString('ascii');
+
+  var regex = /validUntil=(\d+)/;
+
+  var match = decodedString.match(regex);
+
+  if (match === null) {
+    throw new errors.ValidUntilNotFound('ValidUntil not found in api key.');
+  }
+
+  var validUntilMatch = decodedString.match(regex)[1];
+
+  return validUntilMatch - Math.round(new Date().getTime() / 1000);
+};

--- a/test/spec/common/client/interface.js
+++ b/test/spec/common/client/interface.js
@@ -74,7 +74,8 @@ test('AlgoliaSearch client API spec', function(t) {
     'disableSecuredAPIKey',
     'enableRateLimitForward',
     'useSecuredAPIKey',
-    'generateSecuredApiKey'
+    'generateSecuredApiKey',
+    'getSecuredApiKeyRemainingValidity'
   ]);
 
   expectedProperties = expectedProperties.sort();

--- a/test/spec/node/get-secured-api-key-remaining-validity.js
+++ b/test/spec/node/get-secured-api-key-remaining-validity.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var test = require('tape');
+var createFixture = require('../../utils/create-fixture');
+var fixture = createFixture();
+var client = fixture.client;
+
+var now = new Date().getTime() / 1000;
+
+test('client.GetSecuredApiKeyRemainingValidity(): expired key', function(t) {
+  t.plan(1);
+
+  var apiKey = client.generateSecuredApiKey('foo', {
+    validUntil: now - (10 * 60)
+  });
+
+  t.true(client.getSecuredApiKeyRemainingValidity(apiKey) < 0);
+});
+
+test('client.GetSecuredApiKeyRemainingValidity(): valid key', function(t) {
+  t.plan(1);
+
+  var apiKey = client.generateSecuredApiKey('foo', {
+    validUntil: now + (10 * 60)
+  });
+
+  t.true(client.getSecuredApiKeyRemainingValidity(apiKey) > 0);
+});
+
+test('client.GetSecuredApiKeyRemainingValidity(): ValidUntil not found', function(t) {
+  t.plan(1);
+
+  var apiKey = client.generateSecuredApiKey('foo');
+
+  t.throws(function() {
+    client.getSecuredApiKeyRemainingValidity(apiKey);
+  }, 'ValidUntil not found.');
+});


### PR DESCRIPTION
This pull request adds `getSecuredApiKeyRemainingValidity` as specified on the api client specs.

closes #772