### PR TITLE
chore(increase-bundle-size): increases allowed size of jQuery and Ang…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "bundlesize": [
     {
       "path": "./dist/algoliasearch.?(jquery|angular).min.js",
-      "maxSize": "19 kB"
+      "maxSize": "20 kB"
     },
     {
       "path": "./dist/algoliasearchLite.min.js",


### PR DESCRIPTION
This pull request increases the allowed size of jQuery/angular integrations to `20kb`, because of the package is structured, the `errors.js` in included in all files.

As both https://github.com/algolia/algoliasearch-client-javascript/pull/778, https://github.com/algolia/algoliasearch-client-javascript/pull/777 add errors to that file, it's normal that `lite` versions are impacted.