### PR TITLE
chore(transporter): fix typo

### DIFF
--- a/packages/transporter/src/Transporter.ts
+++ b/packages/transporter/src/Transporter.ts
@@ -162,7 +162,7 @@ export class Transporter implements TransporterContract {
             decide(host, response, {
               success: () => resolve(Deserializer.success<TResponse>(response)),
               retry: () => {
-                this.logger.error('Retriable failure', {
+                this.logger.error('Retryable failure', {
                   request,
                   response,
                   host,


### PR DESCRIPTION
This isn't per se a typo, but `retryable` is "more common" https://english.stackexchange.com/questions/364277/which-spelling-is-preferred-retriable-or-retryable
