### PR TITLE
getSecuredApiKeyRemainingValidity  has hanging comma, that throws error at runtime for node.js engine(s) <= 8

### DIFF
--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -321,9 +321,7 @@ AlgoliaSearchNodeJS.prototype.generateSecuredApiKey = function generateSecuredAp
   return new Buffer(securedKey + searchParams).toString('base64');
 };
 
-AlgoliaSearchNodeJS.prototype.getSecuredApiKeyRemainingValidity = function getSecuredApiKeyRemainingValidity(
-  securedAPIKey,
-) {
+AlgoliaSearchNodeJS.prototype.getSecuredApiKeyRemainingValidity = function getSecuredApiKeyRemainingValidity(securedAPIKey) {
   var decodedString = new Buffer(securedAPIKey, 'base64').toString('ascii');
 
   var regex = /validUntil=(\d+)/;


### PR DESCRIPTION

**Summary**
There's currently an issue for older node.js engines that do not support extra commas at the end of a method. 

**Result**
This method will now work for node.js clients