### PR TITLE
fix: unknown parameter `paginate` within findObjects method

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -928,6 +928,9 @@ Index.prototype.findObject = function(findCallback, requestOptions, callback) {
   var paginate = requestOptions.paginate !== undefined ? requestOptions.paginate : true;
   var query = requestOptions.query !== undefined ? requestOptions.query : '';
 
+  delete requestOptions.paginate;
+  delete requestOptions.query;
+
   var that = this;
   var page = 0;
 

--- a/test/spec/common/index/findObject.js
+++ b/test/spec/common/index/findObject.js
@@ -94,9 +94,12 @@ test('findObject: object not found with non matching query', function(t) {
   fauxJax.install();
 
   var index = fixture.index;
-  t.plan(1);
+  t.plan(2);
 
   fauxJax.once('request', function(req) {
+    // Assert paginate/query got deleted from request options.
+    t.equal(req.requestBody, '{"params":"query=Algolia&page=0"}');
+
     req.respond(
       200,
       {},
@@ -131,10 +134,13 @@ test('findObject: object not found without pagination', function(t) {
   fauxJax.install();
 
   var index = fixture.index;
-  t.plan(1);
+  t.plan(2);
 
   var page = 0;
   fauxJax.once('request', function(req) {
+    // Assert paginate/query got deleted from request options.
+    t.equal(req.requestBody, '{"params":"query=&page=0"}');
+
     req.respond(
       200,
       {},


### PR DESCRIPTION
**Summary**

This pull request fixes an issue when people try to find and object without pagination, setting `paginate` to false,  using the `findObject` method. Without the `delete` code introduced in this pull request, the engine returns: `Unknown parameter: paginate`.