### PR TITLE
chore: avoid Array#includes in bundle

### DIFF
--- a/packages/transporter/src/request-options.ts
+++ b/packages/transporter/src/request-options.ts
@@ -10,7 +10,7 @@ export function mapRequestOptions(
   const data: { [key: string]: string } = {};
 
   Object.keys(options).forEach(key => {
-    if (!['timeout', 'headers', 'queryParameters', 'data', 'cacheable'].includes(key)) {
+    if (['timeout', 'headers', 'queryParameters', 'data', 'cacheable'].indexOf(key) === -1) {
       data[key] = options[key]; // eslint-disable-line functional/immutable-data
     }
   });

--- a/specs/fixtures/websites/algoliasearch-lite.com/index.html
+++ b/specs/fixtures/websites/algoliasearch-lite.com/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Array.prototype.includes"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries"></script>
     <script src="algoliasearch-lite.umd.js"></script>
   </head>
   <body></body>

--- a/specs/fixtures/websites/algoliasearch.com/index.html
+++ b/specs/fixtures/websites/algoliasearch.com/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Array.prototype.includes"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries"></script>
     <script src="algoliasearch.umd.js"></script>
   </head>
   <body></body>


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Array#indexOf is IE9, while Array#includes is not in any IE

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

no more includes is used in source files