### PR TITLE
feat(searchClient): add clearCache method, which clears request & response caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.31KB"
+      "maxSize": "7.36KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",
-      "maxSize": "4.12KB"
+      "maxSize": "4.18KB"
     }
   ]
 }

--- a/packages/client-search/src/__tests__/unit/search-client.test.ts
+++ b/packages/client-search/src/__tests__/unit/search-client.test.ts
@@ -40,3 +40,70 @@ test('get logs', async () => {
 
   verify(transporterMock.read(anything(), undefined)).once();
 });
+
+test('clearCache', async () => {
+  const client = algoliasearch('appId', 'apiKey');
+
+  client.transporter.requestsCache.set('bla', 'blo');
+  client.transporter.responsesCache.set('bla', 'blo');
+
+  if (testing.isBrowser()) {
+    await expect(
+      client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('blo');
+    await expect(
+      client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('blo');
+  } else {
+    // node uses a null cache, so these assertions don't make sense there
+    await expect(
+      client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('wrong');
+    await expect(
+      client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('wrong');
+  }
+
+  await client.clearCache();
+
+  await expect(
+    client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+  ).resolves.toBe('wrong');
+  await expect(
+    client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+  ).resolves.toBe('wrong');
+});
+
+test('clearCache without promise', async () => {
+  const client = algoliasearch('appId', 'apiKey');
+
+  client.transporter.requestsCache.set('bla', 'blo');
+  client.transporter.responsesCache.set('bla', 'blo');
+
+  if (testing.isBrowser()) {
+    await expect(
+      client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('blo');
+    await expect(
+      client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('blo');
+  } else {
+    // node uses a null cache, so these assertions don't make sense there
+    await expect(
+      client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('wrong');
+    await expect(
+      client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+    ).resolves.toBe('wrong');
+  }
+
+  // no await, since default memory caches _actually_ are instant
+  client.clearCache();
+
+  await expect(
+    client.transporter.requestsCache.get('bla', () => Promise.resolve('wrong'))
+  ).resolves.toBe('wrong');
+  await expect(
+    client.transporter.responsesCache.get('bla', () => Promise.resolve('wrong'))
+  ).resolves.toBe('wrong');
+});

--- a/packages/client-search/src/createSearchClient.ts
+++ b/packages/client-search/src/createSearchClient.ts
@@ -52,6 +52,12 @@ export const createSearchClient: CreateClient<
     addAlgoliaAgent(segment: string, version?: string): void {
       transporter.userAgent.add({ segment, version });
     },
+    clearCache(): Promise<void> {
+      return Promise.all([
+        transporter.requestsCache.clear(),
+        transporter.responsesCache.clear(),
+      ]).then(() => undefined);
+    },
   };
 
   return addMethods(base, options.methods);

--- a/packages/client-search/src/types/SearchClient.ts
+++ b/packages/client-search/src/types/SearchClient.ts
@@ -15,4 +15,9 @@ export type SearchClient = {
    * Mutates the transporter, adding the given user agent.
    */
   readonly addAlgoliaAgent: (segment: string, version?: string) => void;
+
+  /**
+   * clears request & response caches
+   */
+  readonly clearCache: () => Promise<void>;
 };


### PR DESCRIPTION
This method returns a promise, but in the default implementation, clearing the cache is actually instant, so the promises don't _need_ to be awaited.