### PR TITLE
chore(ts): simplify WithoutCredentials

### DIFF
--- a/packages/algoliasearch/src/types/AlgoliaSearchOptions.ts
+++ b/packages/algoliasearch/src/types/AlgoliaSearchOptions.ts
@@ -3,10 +3,7 @@ import { ClientTransporterOptions } from '@algolia/client-common';
 import { RecommendationClientOptions } from '@algolia/client-recommendation';
 import { SearchClientOptions } from '@algolia/client-search';
 
-export type WithoutCredentials<TClient> = Pick<
-  TClient,
-  Exclude<keyof TClient, 'appId'> & Exclude<keyof TClient, 'apiKey'>
->;
+export type WithoutCredentials<TClient> = Omit<TClient, 'appId' | 'apiKey'>;
 
 export type AlgoliaSearchOptions = Partial<ClientTransporterOptions> &
   WithoutCredentials<SearchClientOptions>;


### PR DESCRIPTION
Omit is included since TS 3.5, which is iirc over the oldest version we support.