### PR TITLE
fix: dom-exception on access to localStorage

### DIFF
--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -5,7 +5,16 @@ import { BrowserLocalStorageOptions } from '.';
 export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptions): Cache {
   const namespaceKey = `algoliasearch-client-js-${options.key}`;
 
-  const getStorage = () => options.localStorage || window.localStorage;
+  // eslint-disable-next-line functional/no-let
+  let storage: Storage;
+  const getStorage = () => {
+    if (storage === undefined) {
+      storage = options.localStorage || window.localStorage;
+    }
+
+    return storage;
+  };
+
   const getNamespace = <TValue>(): Record<string, TValue> => {
     return JSON.parse(getStorage().getItem(namespaceKey) || '{}');
   };

--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -3,11 +3,11 @@ import { Cache, CacheEvents } from '@algolia/cache-common';
 import { BrowserLocalStorageOptions } from '.';
 
 export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptions): Cache {
-  const storage = options.localStorage || window.localStorage;
   const namespaceKey = `algoliasearch-client-js-${options.key}`;
 
+  const getStorage = () => options.localStorage || window.localStorage;
   const getNamespace = <TValue>(): Record<string, TValue> => {
-    return JSON.parse(storage.getItem(namespaceKey) || '{}');
+    return JSON.parse(getStorage().getItem(namespaceKey) || '{}');
   };
 
   return {
@@ -38,7 +38,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
         // eslint-disable-next-line functional/immutable-data
         namespace[JSON.stringify(key)] = value;
 
-        storage.setItem(namespaceKey, JSON.stringify(namespace));
+        getStorage().setItem(namespaceKey, JSON.stringify(namespace));
 
         return value;
       });
@@ -51,13 +51,13 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
         // eslint-disable-next-line functional/immutable-data
         delete namespace[JSON.stringify(key)];
 
-        storage.setItem(namespaceKey, JSON.stringify(namespace));
+        getStorage().setItem(namespaceKey, JSON.stringify(namespace));
       });
     },
 
     clear(): Readonly<Promise<void>> {
       return Promise.resolve().then(() => {
-        storage.removeItem(namespaceKey);
+        getStorage().removeItem(namespaceKey);
       });
     },
   };


### PR DESCRIPTION
fix: #997 

The access to the localStorage was being performed on the constructor of the `localStorage` driver making the `algoliasearch` function throwing the following exception:

<img width="737" alt="Screenshot 2020-02-07 at 11 37 50" src="https://user-images.githubusercontent.com/5457236/74022670-50f33d00-499e-11ea-85c7-0fa7c55c6f5d.png">

This pull request delays the access to the localStorage to the async API provided by `get`, `set`, and `clear`, so the error can be `catch` - making the `fallbackable` driver proxy to the next driver in the chain.

https://github.com/algolia/algoliasearch-client-javascript/blob/d862a912d764655a415a9bffc25634d625ebe88d/packages/cache-common/src/createFallbackableCache.ts#L21