### PR TITLE
fix: missing cursor while using browseObjects

### DIFF
--- a/packages/client-search/src/createBrowsablePromise.ts
+++ b/packages/client-search/src/createBrowsablePromise.ts
@@ -23,6 +23,7 @@ export function createBrowsablePromise<TObject>(
 
         // eslint-disable-next-line functional/immutable-data
         data.page++;
+        data.cursor = response.cursor;
 
         return browse();
       });


### PR DESCRIPTION
Api return ApiError when the request is the third without cursor.
Api Request has only 3 tries without cursor params

Message: 'you should pass cursor of current page to fetch next page'