### PR TITLE
fix: wrong behaviour on browsing to next page/cursor in browse methods

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,7 @@ module.exports = {
         testPathIgnorePatterns: [
           'packages/client-search/src/__tests__/integration/api-keys.test.ts',
           'packages/client-search/src/__tests__/integration/batching.test.ts',
+          'packages/client-search/src/__tests__/integration/browsing.test.ts',
           'packages/client-search/src/__tests__/integration/chunked-batch.test.ts',
           'packages/client-search/src/__tests__/integration/copy-and-move-index.test.ts',
           'packages/client-search/src/__tests__/integration/exists.test.ts',

--- a/packages/client-search/src/__tests__/integration/browsing.test.ts
+++ b/packages/client-search/src/__tests__/integration/browsing.test.ts
@@ -1,0 +1,134 @@
+import {
+  browseObjects,
+  BrowseOptions,
+  browseRules,
+  browseSynonyms,
+  ObjectWithObjectID,
+  SearchIndex,
+} from '../..';
+import { createFaker } from '../../../../client-common/src/__tests__/createFaker';
+import { TestSuite } from '../../../../client-common/src/__tests__/TestSuite';
+
+const testSuite = new TestSuite('browsing');
+
+afterAll(() => testSuite.cleanUp());
+
+test(testSuite.testName, async () => {
+  const index = testSuite.makeIndex();
+
+  const browse = async (
+    method: (index: SearchIndex) => any,
+    options: { hitsPerPage?: number } = {}
+  ) => {
+    const result = {
+      hitsCount: 0,
+      batchCount: 0,
+    };
+
+    const browseOptions: BrowseOptions<ObjectWithObjectID> = {
+      ...options,
+      batch(batch) {
+        result.batchCount++;
+        result.hitsCount = result.hitsCount + batch.length;
+      },
+    };
+
+    await method(index)(browseOptions);
+
+    return result;
+  };
+
+  await index.setSettings({}).wait();
+
+  const objectsCase = {
+    method: browseObjects,
+    async withDataset(number: number) {
+      await index.clearObjects();
+
+      await index.saveObjects(createFaker().objects(number)).wait();
+    },
+    cursorBased: true,
+  };
+
+  const rulesCase = {
+    method: browseRules,
+    async withDataset(number: number) {
+      await index.clearRules();
+
+      await index
+        .saveRules(
+          [...Array(number).keys()].map(objectID => ({
+            objectID: objectID.toString(),
+            consequence: { params: { filters: 'brand:OnePlus' } },
+          }))
+        )
+        .wait();
+    },
+    cursorBased: false,
+  };
+
+  const synonymsCase = {
+    method: browseSynonyms,
+    async withDataset(number: number) {
+      await index.clearSynonyms();
+
+      await index
+        .saveSynonyms(
+          [...Array(number).keys()].map(objectID => ({
+            objectID: objectID.toString(),
+            type: 'synonym',
+            synonyms: ['gba', 'gameboy advance', 'game boy advance'],
+          }))
+        )
+        .wait();
+    },
+    cursorBased: false,
+  };
+
+  await Promise.all(
+    [objectsCase, synonymsCase, rulesCase].map(async testCase => {
+      await expect(browse(testCase.method)).resolves.toEqual({
+        hitsCount: 0,
+        batchCount: 1,
+      });
+
+      await testCase.withDataset(10);
+
+      await Promise.all([
+        expect(browse(testCase.method)).resolves.toEqual({
+          hitsCount: 10,
+          batchCount: 1,
+        }),
+
+        expect(browse(testCase.method, { hitsPerPage: 9 })).resolves.toEqual({
+          hitsCount: 10,
+          batchCount: 2,
+        }),
+
+        expect(browse(testCase.method, { hitsPerPage: 10 })).resolves.toEqual({
+          hitsCount: 10,
+          batchCount: testCase.cursorBased ? 1 : 2,
+        }),
+
+        expect(browse(testCase.method, { hitsPerPage: 11 })).resolves.toEqual({
+          hitsCount: 10,
+          batchCount: 2,
+        }),
+      ]);
+
+      await testCase.withDataset(1000);
+
+      await Promise.all([
+        expect(browse(testCase.method)).resolves.toEqual({
+          hitsCount: 1000,
+          batchCount: testCase.cursorBased ? 1 : 2,
+        }),
+
+        expect(browse(testCase.method, { hitsPerPage: 999 })).resolves.toEqual({
+          hitsCount: 1000,
+          batchCount: 2,
+        }),
+      ]);
+    })
+  );
+});

--- a/packages/client-search/src/__tests__/integration/browsing.test.ts
+++ b/packages/client-search/src/__tests__/integration/browsing.test.ts
@@ -16,6 +16,12 @@ afterAll(() => testSuite.cleanUp());
 test(testSuite.testName, async () => {
   const index = testSuite.makeIndex();
 
+  // First lets create the index.
+  await index.setSettings({}).wait();
+
+  // Then, let's create a generic browse function that
+  // will take a browseMethod, and get metrics such as
+  // the number of retrieved hits and number of batches.
   const browse = async (
     method: (index: SearchIndex) => any,
     options: { hitsPerPage?: number } = {}
@@ -38,7 +44,9 @@ test(testSuite.testName, async () => {
     return result;
   };
 
-  await index.setSettings({}).wait();
+  // Next, let's create a test case for each browse type, note that
+  // each test case as a specific method, a specific way of browsing,
+  // and also a specific way of reseting the dataset.
 
   const objectsCase = {
     method: browseObjects,
@@ -85,6 +93,8 @@ test(testSuite.testName, async () => {
     cursorBased: false,
   };
 
+  // Finaly let's start the testing part. For each browse type lets test
+  // it against, and multiple numbers of datasets and conditions.
   await Promise.all(
     [objectsCase, synonymsCase, rulesCase].map(async testCase => {
       await expect(browse(testCase.method)).resolves.toEqual({

--- a/packages/client-search/src/__tests__/integration/browsing.test.ts
+++ b/packages/client-search/src/__tests__/integration/browsing.test.ts
@@ -112,7 +112,7 @@ test(testSuite.testName, async () => {
 
         expect(browse(testCase.method, { hitsPerPage: 11 })).resolves.toEqual({
           hitsCount: 10,
-          batchCount: 2,
+          batchCount: 1,
         }),
       ]);
 

--- a/packages/client-search/src/createBrowsablePromise.ts
+++ b/packages/client-search/src/createBrowsablePromise.ts
@@ -28,7 +28,7 @@ export function createBrowsablePromise<TObject>(
 
         /**
          * Finally, if the response contains a cursor, we browse to the next
-         * batch using that same cursor. Otherwise, we just use the tradicional
+         * batch using that same cursor. Otherwise, we just use the traditional
          * browsing using the page element.
          */
         if (response.cursor) {

--- a/packages/client-search/src/createBrowsablePromise.ts
+++ b/packages/client-search/src/createBrowsablePromise.ts
@@ -1,30 +1,45 @@
-import { BrowseOptions, BrowseResponse } from '.';
+import { BrowseOptions, BrowseRequestData, BrowseResponse } from '.';
 
 export function createBrowsablePromise<TObject>(
   options: {
     readonly shouldStop: (response: BrowseResponse<TObject>) => boolean;
-    readonly request: (data: {
-      readonly page: number;
-    }) => Readonly<Promise<BrowseResponse<TObject>>>;
+    readonly request: (data: BrowseRequestData) => Readonly<Promise<BrowseResponse<TObject>>>;
   } & BrowseOptions<TObject>
 ): Readonly<Promise<void>> {
   return new Promise<void>(resolve => {
-    const data = { page: 0 };
-
-    const browse = (): Promise<void> => {
+    const browse = (data: BrowseRequestData = {}): Promise<void> => {
       return options.request(data).then(response => {
+        /**
+         * First we send to the developer the
+         * batch retrieved from the API.
+         */
         if (options.batch !== undefined) {
           options.batch(response.hits);
         }
 
+        /**
+         * Then, we ask to the browse concrete implementation
+         * if we should stop browsing. As example, the `browseObjects`
+         * method will stop if the cursor is not present on the response.
+         */
         if (options.shouldStop(response)) {
           return resolve();
         }
 
-        // eslint-disable-next-line functional/immutable-data
-        data.page++;
+        /**
+         * Finally, if the response contains a cursor, we browse to the next
+         * batch using that same cursor. Otherwise, we just use the tradicional
+         * browsing using the page element.
+         */
+        if (response.cursor) {
+          return browse({
+            cursor: response.cursor,
+          });
+        }
 
-        return browse();
+        return browse({
+          page: (data.page || 0) + 1,
+        });
       });
     };
 

--- a/packages/client-search/src/methods/index/browseRules.ts
+++ b/packages/client-search/src/methods/index/browseRules.ts
@@ -23,7 +23,7 @@ export const browseRules = (base: SearchIndex) => {
       ...options,
       shouldStop: response => response.hits.length < options.hitsPerPage,
       request(data) {
-        return searchRules(base)('', { ...requestOptions, ...data }).then(
+        return searchRules(base)('', { ...options, ...data }).then(
           (response): BrowseResponse<Rule> => {
             return {
               ...response,

--- a/packages/client-search/src/methods/index/browseSynonyms.ts
+++ b/packages/client-search/src/methods/index/browseSynonyms.ts
@@ -23,7 +23,7 @@ export const browseSynonyms = (base: SearchIndex) => {
       ...options,
       shouldStop: response => response.hits.length < options.hitsPerPage,
       request(data) {
-        return searchSynonyms(base)('', { ...requestOptions, ...data }).then(
+        return searchSynonyms(base)('', { ...options, ...data }).then(
           (response): BrowseResponse<Synonym> => {
             return {
               ...response,

--- a/packages/client-search/src/types/BrowseRequestData.ts
+++ b/packages/client-search/src/types/BrowseRequestData.ts
@@ -1,0 +1,11 @@
+export type BrowseRequestData = {
+  /**
+   * If available, should be used for browsing to the next page.
+   */
+  readonly cursor?: string;
+
+  /**
+   * If cursor is not available, should be used for browsing to the next page.
+   */
+  readonly page?: number;
+};

--- a/packages/client-search/src/types/index.ts
+++ b/packages/client-search/src/types/index.ts
@@ -10,6 +10,7 @@ export * from './BatchActionType';
 export * from './BatchRequest';
 export * from './BatchResponse';
 export * from './BrowseOptions';
+export * from './BrowseRequestData';
 export * from './BrowseResponse';
 export * from './ChunkOptions';
 export * from './ChunkedBatchResponse';


### PR DESCRIPTION
This pull request addresses found problems on `browse` related methods in some edge cases:

1. When an index is too big, the browsing using `pages` is no longer available by the API giving the following error: `you should pass cursor of the current page to fetch next page`. So we adapt the browsable promise saying that when the response as a cursor, we use the cursor for browsing to the next page. ` : https://github.com/algolia/algoliasearch-client-javascript/compare/fix/browse-methods-edge-cases?expand=1#diff-dc6449cb3a3afc56b777c2dd08bb26c9R34

2. On the page related browses ( synonyms and rules ), the `hitsPerPage` wasn't sent to Algolia. Causing Algolia to send always 20 synonyms per batch, and early stop on pagination as `shouldStop: response => response.hits.length < 1000,`. https://github.com/algolia/algoliasearch-client-javascript/compare/fix/browse-methods-edge-cases?expand=1#diff-2f2de2f87e60dfb956427b9e0bdc21a7R26

Let me know if you want me to explain those two cases orally.

closes #1009 