### PR TITLE
fix: abtests field on getAbTestsResponse

### DIFF
--- a/packages/client-analytics/src/__tests__/integration/ab-testing.test.ts
+++ b/packages/client-analytics/src/__tests__/integration/ab-testing.test.ts
@@ -43,7 +43,7 @@ test(testSuite.testName, async () => {
   {
     const getABTestsResponse = await analytics.getABTests();
 
-    if (getABTestsResponse.count) {
+    if (getABTestsResponse.abtests) {
       const oldABTests = getABTestsResponse.abtests;
 
       await Promise.all(
@@ -112,8 +112,8 @@ test(testSuite.testName, async () => {
   // corresponds to the original one
   {
     const all = await analytics.getABTests();
-    const found = all.abtests.find(t => t.abTestID === abTestID);
-    if (found === undefined) {
+    const found = all.abtests && all.abtests.find(t => t.abTestID === abTestID);
+    if (!found) {
       throw new Error('Ab test not found.');
     }
 

--- a/packages/client-analytics/src/types/GetABTestsResponse.ts
+++ b/packages/client-analytics/src/types/GetABTestsResponse.ts
@@ -14,5 +14,5 @@ export type GetABTestsResponse = {
   /**
    * The list of ab tests.
    */
-  readonly abtests: readonly GetABTestResponse[];
+  readonly abtests: readonly GetABTestResponse[] | null;
 };


### PR DESCRIPTION
This pull request fixes the `abtests` field on getAbTestsResponse.