### PR TITLE
fix: header field x-algolia-user-id is not allowed by access-control-allow-headers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-commonjs, functional/immutable-data, sonarjs/no-duplicate-string */
+/* eslint-disable import/no-commonjs, functional/immutable-data */
 const { pathsToModuleNameMapper } = require('ts-jest/utils');
 
 const { compilerOptions } = require('./tsconfig');
@@ -65,7 +65,6 @@ module.exports = {
         testPathIgnorePatterns: [
           'packages/requester-node-http/*',
           'packages/client-search/src/__tests__/integration/secured-api-keys.test.ts',
-          'packages/client-search/src/__tests__/integration/mcm.test.ts',
         ],
         globals: {
           environment: 'browser',
@@ -84,7 +83,6 @@ module.exports = {
           'packages/requester-browser-xhr/*',
           'packages/cache-browser-local-storage/*',
           'packages/algoliasearch/src/__tests__/lite.test.ts',
-          'packages/client-search/src/__tests__/integration/mcm.test.ts',
         ],
         globals: {
           environment: 'node',

--- a/packages/client-search/src/__tests__/integration/mcm.test.ts
+++ b/packages/client-search/src/__tests__/integration/mcm.test.ts
@@ -57,7 +57,7 @@ test(testSuite.testName, async () => {
     client.assignUserIDs([userID(1), userID(2)], firstClusterName)
   ).resolves.toHaveProperty('createdAt');
 
-  const waitUserID = async (number: number) => {
+  const waitAssign = async (number: number) => {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
@@ -70,8 +70,10 @@ test(testSuite.testName, async () => {
     }
   };
 
+  await Promise.all([0, 1, 2].map(waitAssign));
+
   for (let number = 0; number < 3; number++) {
-    await expect(waitUserID(number)).resolves.toMatchObject({
+    await expect(client.getUserID(userID(number))).resolves.toMatchObject({
       userID: userID(number),
       clusterName: firstClusterName,
       nbRecords: 0,
@@ -143,6 +145,23 @@ test(testSuite.testName, async () => {
   for (let number = 0; number < 3; number++) {
     await expect(removeUserID(number)).resolves.toHaveProperty('deletedAt');
   }
+
+  const waitRemove = async (number: number) => {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        await client.getUserID(userID(number));
+      } catch (e) {
+        if (e.status !== 404) {
+          throw e;
+        }
+
+        return;
+      }
+    }
+  };
+
+  await Promise.all([0, 1, 2].map(waitRemove));
 
   for (let number = 0; number < 3; number++) {
     await expect(client.getUserID(userID(number))).rejects.toMatchObject({

--- a/packages/client-search/src/__tests__/integration/mcm.test.ts
+++ b/packages/client-search/src/__tests__/integration/mcm.test.ts
@@ -31,6 +31,13 @@ test(testSuite.testName, async () => {
   // @ts-ignore
   client.transporter = createRetryableTransporter(client.transporter);
 
+  // @ts-ignore
+  client.transporter.timeouts = {
+    connect: 2,
+    read: 5,
+    write: 30,
+  };
+
   const response = await client.listClusters();
 
   expect(response.clusters).toHaveLength(2);
@@ -42,15 +49,13 @@ test(testSuite.testName, async () => {
       .replace(/:/g, '-')
       .replace(/\./g, '-');
 
-  const assignUserIDResponse = await client.assignUserID(userID(0), firstClusterName);
-  expect(assignUserIDResponse).toHaveProperty('createdAt');
-
-  const assignUserIDsResponse = await client.assignUserIDs(
-    [userID(1), userID(2)],
-    firstClusterName
+  await expect(client.assignUserID(userID(0), firstClusterName)).resolves.toHaveProperty(
+    'createdAt'
   );
 
-  expect(assignUserIDsResponse).toHaveProperty('createdAt');
+  await expect(
+    client.assignUserIDs([userID(1), userID(2)], firstClusterName)
+  ).resolves.toHaveProperty('createdAt');
 
   const waitUserID = async (number: number) => {
     // eslint-disable-next-line no-constant-condition
@@ -58,13 +63,15 @@ test(testSuite.testName, async () => {
       try {
         return await client.getUserID(userID(number));
       } catch (e) {
-        // @todo Be more specific here.
+        if (e.status !== 404 || e.message !== 'Mapping does not exist for this userID') {
+          throw e;
+        }
       }
     }
   };
 
   for (let number = 0; number < 3; number++) {
-    expect(await waitUserID(number)).toMatchObject({
+    await expect(waitUserID(number)).resolves.toMatchObject({
       userID: userID(number),
       clusterName: firstClusterName,
       nbRecords: 0,
@@ -94,11 +101,14 @@ test(testSuite.testName, async () => {
     'dataSize',
   ]);
 
-  expect(
-    await client.listUserIDs({
+  await expect(
+    client.listUserIDs({
       hitsPerPage: 1,
     })
-  ).toHaveLength(1);
+  ).resolves.toMatchObject({
+    hitsPerPage: 1,
+    page: 0,
+  });
 
   expect(listUserIDsResponse.userIDs.length > 0).toBe(true);
   expect(Object.keys(listUserIDsResponse.userIDs[0])).toEqual([
@@ -123,21 +133,22 @@ test(testSuite.testName, async () => {
       try {
         return await client.removeUserID(userID(number));
       } catch (e) {
-        // @todo Be more specific here...
+        if (e.status !== 400 || e.message !== `User '${userID(number)}' is already migrating`) {
+          throw e;
+        }
       }
     }
   };
 
   for (let number = 0; number < 3; number++) {
-    expect(await removeUserID(number)).toHaveProperty('deletedAt');
+    await expect(removeUserID(number)).resolves.toHaveProperty('deletedAt');
   }
 
   for (let number = 0; number < 3; number++) {
-    await expect(client.getUserID(userID(number))).rejects.toEqual({
+    await expect(client.getUserID(userID(number))).rejects.toMatchObject({
       message: 'Mapping does not exist for this userID',
       name: 'ApiError',
       status: 404,
     });
   }
-  // @todo remove past users ids.
 });

--- a/packages/client-search/src/__tests__/integration/mcm.test.ts
+++ b/packages/client-search/src/__tests__/integration/mcm.test.ts
@@ -13,7 +13,7 @@ const createRetryableTransporter = (client: Transporter): Transporter => {
       return (...args: any) => {
         return createRetryablePromise(retry => {
           return obj[method](...args).catch((err: ApiError) => {
-            if (err.status === 500 && err.message === 'Remote side is unreachable') {
+            if (err.message === 'Remote side is unreachable') {
               return retry();
             }
 

--- a/packages/client-search/src/methods/client/assignUserID.ts
+++ b/packages/client-search/src/methods/client/assignUserID.ts
@@ -12,15 +12,13 @@ export const assignUserID = (base: SearchClient) => {
     const mappedRequestOptions = createMappedRequestOptions(requestOptions);
 
     // eslint-disable-next-line functional/immutable-data
-    mappedRequestOptions.headers['X-Algolia-User-ID'] = userID;
+    mappedRequestOptions.queryParameters['X-Algolia-User-ID'] = userID;
 
     return base.transporter.write(
       {
         method: MethodEnum.Post,
         path: '1/clusters/mapping',
-        data: {
-          cluster: clusterName,
-        },
+        data: { cluster: clusterName },
       },
       mappedRequestOptions
     );

--- a/packages/client-search/src/methods/client/removeUserID.ts
+++ b/packages/client-search/src/methods/client/removeUserID.ts
@@ -11,7 +11,7 @@ export const removeUserID = (base: SearchClient) => {
     const mappedRequestOptions = createMappedRequestOptions(requestOptions);
 
     // eslint-disable-next-line functional/immutable-data
-    mappedRequestOptions.headers['X-Algolia-User-ID'] = userID;
+    mappedRequestOptions.queryParameters['X-Algolia-User-ID'] = userID;
 
     return base.transporter.write(
       {


### PR DESCRIPTION
Multi-cluster methods using `x-algolia-user-id` header on `POST`|`DELETE` verbs may encounter the bug `header field x-algolia-user-id is not allowed by access-control-allow-headers` while using this methods on the browser.

This PR fixes that exact same issue passing `x-algolia-user-id` on the query parameter instead of the browser.

In addition,  we also increase the timeouts of the transporter layer to avoid flakiness, and we did reactivate the mcm test now that the mcm cluster is alive again.