### PR TITLE
feat(browse): make shouldStop public on the browsable methods

### DIFF
--- a/packages/client-search/src/methods/index/browseObjects.ts
+++ b/packages/client-search/src/methods/index/browseObjects.ts
@@ -12,7 +12,7 @@ import {
 
 export const browseObjects = (base: SearchIndex) => {
   return <TObject>(
-    requestOptions?: SearchOptions & BrowseOptions<TObject> & RequestOptions 
+    requestOptions?: SearchOptions & BrowseOptions<TObject> & RequestOptions
   ): Readonly<Promise<void>> => {
     return createBrowsablePromise<TObject>({
       shouldStop: response => response.cursor === undefined,

--- a/packages/client-search/src/methods/index/browseObjects.ts
+++ b/packages/client-search/src/methods/index/browseObjects.ts
@@ -12,11 +12,11 @@ import {
 
 export const browseObjects = (base: SearchIndex) => {
   return <TObject>(
-    requestOptions?: SearchOptions & BrowseOptions<TObject> & RequestOptions
+    requestOptions?: SearchOptions & BrowseOptions<TObject> & RequestOptions 
   ): Readonly<Promise<void>> => {
     return createBrowsablePromise<TObject>({
-      ...requestOptions,
       shouldStop: response => response.cursor === undefined,
+      ...requestOptions,
       request: (data: Record<string, any>): Readonly<Promise<BrowseResponse<TObject>>> =>
         base.transporter.read(
           {

--- a/packages/client-search/src/methods/index/browseRules.ts
+++ b/packages/client-search/src/methods/index/browseRules.ts
@@ -20,8 +20,8 @@ export const browseRules = (base: SearchIndex) => {
     };
 
     return createBrowsablePromise<Rule>({
-      ...options,
       shouldStop: response => response.hits.length < options.hitsPerPage,
+      ...options,
       request(data) {
         return searchRules(base)('', { ...options, ...data }).then(
           (response): BrowseResponse<Rule> => {

--- a/packages/client-search/src/methods/index/browseSynonyms.ts
+++ b/packages/client-search/src/methods/index/browseSynonyms.ts
@@ -20,8 +20,8 @@ export const browseSynonyms = (base: SearchIndex) => {
     };
 
     return createBrowsablePromise<Synonym>({
-      ...options,
       shouldStop: response => response.hits.length < options.hitsPerPage,
+      ...options,
       request(data) {
         return searchSynonyms(base)('', { ...options, ...data }).then(
           (response): BrowseResponse<Synonym> => {

--- a/packages/client-search/src/types/BrowseOptions.ts
+++ b/packages/client-search/src/types/BrowseOptions.ts
@@ -6,8 +6,10 @@ export type BrowseOptions<TObject> = {
    * The callback called for each batch of objects.
    */
   readonly batch?: (batch: ReadonlyArray<TObject & ObjectWithObjectID>) => any;
+
   /**
-   * condition to stop browsing. By default this checks whether there's any more content to get
+   * The callback called to determine if the browse should stop. By
+   * default this checks whether there's any more content to get.
    */
   readonly shouldStop?: (response: BrowseResponse<TObject>) => boolean;
 };

--- a/packages/client-search/src/types/BrowseOptions.ts
+++ b/packages/client-search/src/types/BrowseOptions.ts
@@ -1,3 +1,4 @@
+import { BrowseResponse } from '.';
 import { ObjectWithObjectID } from './ObjectWithObjectID';
 
 export type BrowseOptions<TObject> = {
@@ -5,4 +6,5 @@ export type BrowseOptions<TObject> = {
    * The callback called for each batch of objects.
    */
   readonly batch?: (batch: ReadonlyArray<TObject & ObjectWithObjectID>) => any;
+  readonly shouldStop?: (response: BrowseResponse<TObject>) => boolean;
 };

--- a/packages/client-search/src/types/BrowseOptions.ts
+++ b/packages/client-search/src/types/BrowseOptions.ts
@@ -6,5 +6,8 @@ export type BrowseOptions<TObject> = {
    * The callback called for each batch of objects.
    */
   readonly batch?: (batch: ReadonlyArray<TObject & ObjectWithObjectID>) => any;
+  /**
+   * condition to stop browsing. By default this checks whether there's any more content to get
+   */
   readonly shouldStop?: (response: BrowseResponse<TObject>) => boolean;
 };


### PR DESCRIPTION
Exposing `shouldStop` allows people to create a different reason to stop browsing, e.g. if they only need the first 10.000 results instead of the whole index.

see #991 for use case examples