### PR TITLE
chore(missing-settings-tests): adds missing tests on settings

### DIFF
--- a/packages/client-search/src/__tests__/integration/settings.test.ts
+++ b/packages/client-search/src/__tests__/integration/settings.test.ts
@@ -80,6 +80,13 @@ test(testSuite.testName, async () => {
       fi: ['attribute3'],
     },
     keepDiacriticsOnCharacters: 'øé',
+    queryLanguages: ['en', 'fr'],
+    alternativesAsExact: ['ignorePlurals'],
+    advancedSyntaxFeatures: ['exactPhrase'],
+    userData: {
+      customUserData: 42.0,
+    },
+    indexLanguages: ['ja'],
   };
 
   await index.setSettings(settings1).wait();


### PR DESCRIPTION
This pull request sync the settings test with the current CTS.

Addresses https://github.com/algolia/algoliasearch-client-specs-internal/pull/38