### PR TITLE
chore(forces-single-host-on-cts): uses fixed host and fixed timeouts

### DIFF
--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -43,6 +43,21 @@ export class TestSuite {
   ) {
     let client = this.algoliasearch(`${process.env[appIdEnv]}`, `${process.env[apiKeyEnv]}`);
 
+    // To ensure `Consistency` during the Common Test Suite, we
+    // force the transporter to work with a single host in the
+    // list: { dsn:read, dsn:write, host-1, host-2, host-3 }
+    client.transporter.hosts = [client.transporter.hosts[2]];
+
+    // Also, since we are targeting always the same host, the
+    // server may take a litle more than expected to answer.
+    // To avoid timeouts we increase the timeouts duration
+    // @ts-ignore
+    client.transporter.timeouts = {
+      connect: 5,
+      read: 10,
+      write: 30,
+    };
+
     if (testing.isBrowserLite()) {
       // @ts-ignore
       client = addMethods(client, {

--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -53,8 +53,8 @@ export class TestSuite {
     // To avoid timeouts we increase the timeouts duration
     // @ts-ignore
     client.transporter.timeouts = {
-      connect: 5,
-      read: 10,
+      connect: 30,
+      read: 30,
       write: 30,
     };
 

--- a/packages/client-search/src/__tests__/integration/api-keys.test.ts
+++ b/packages/client-search/src/__tests__/integration/api-keys.test.ts
@@ -7,13 +7,6 @@ const testSuite = new TestSuite('api_keys');
 test(testSuite.testName, async () => {
   const client = testSuite.makeSearchClient();
 
-  // @ts-ignore
-  client.transporter.timeouts = {
-    connect: 2,
-    read: 5,
-    write: 30,
-  };
-
   const apiKeyOptions = {
     description: 'A description',
     indexes: ['index'],

--- a/packages/client-search/src/__tests__/integration/copy-and-move-index.test.ts
+++ b/packages/client-search/src/__tests__/integration/copy-and-move-index.test.ts
@@ -42,16 +42,16 @@ test(testSuite.testName, async () => {
   await waitResponses(responses);
   responses = [];
 
-  const indexSettings = testSuite.makeIndex(`${index.indexName}copy_index_settings`);
+  const indexSettings = client.initIndex(`${index.indexName}copy_index_settings`);
   responses.push(client.copySettings(index.indexName, indexSettings.indexName));
 
-  const indexSynonyms = testSuite.makeIndex(`${index.indexName}copy_index_synonyms`);
+  const indexSynonyms = client.initIndex(`${index.indexName}copy_index_synonyms`);
   responses.push(client.copySynonyms(index.indexName, indexSynonyms.indexName));
 
-  const indexRules = testSuite.makeIndex(`${index.indexName}copy_index_rules`);
+  const indexRules = client.initIndex(`${index.indexName}copy_index_rules`);
   responses.push(client.copyRules(index.indexName, indexRules.indexName));
 
-  const indexFull = testSuite.makeIndex(`${index.indexName}copy_index_full`);
+  const indexFull = client.initIndex(`${index.indexName}copy_index_full`);
   responses.push(client.copyIndex(index.indexName, indexFull.indexName));
 
   await waitResponses(responses);
@@ -80,7 +80,7 @@ test(testSuite.testName, async () => {
   expect((await indexRules.getSettings()).attributesForFaceting).toEqual(null);
   expect((await indexSynonyms.getSettings()).attributesForFaceting).toEqual(null);
 
-  const indexMoved = testSuite.makeIndex(`${index.indexName}move_index`);
+  const indexMoved = client.initIndex(`${index.indexName}move_index`);
   await client.moveIndex(index.indexName, indexMoved.indexName).wait();
 
   expect(await index.exists()).toBe(false);

--- a/packages/client-search/src/__tests__/integration/copy-and-move-index.test.ts
+++ b/packages/client-search/src/__tests__/integration/copy-and-move-index.test.ts
@@ -4,8 +4,8 @@ import { TestSuite } from '../../../../client-common/src/__tests__/TestSuite';
 const testSuite = new TestSuite('copy_and_move_index');
 
 test(testSuite.testName, async () => {
-  const index = testSuite.makeIndex();
   const client = testSuite.makeSearchClient();
+  const index = client.initIndex(testSuite.makeIndexName());
 
   let responses = [];
 

--- a/packages/client-search/src/__tests__/integration/mcm.test.ts
+++ b/packages/client-search/src/__tests__/integration/mcm.test.ts
@@ -31,13 +31,6 @@ test(testSuite.testName, async () => {
   // @ts-ignore
   client.transporter = createRetryableTransporter(client.transporter);
 
-  // @ts-ignore
-  client.transporter.timeouts = {
-    connect: 2,
-    read: 5,
-    write: 30,
-  };
-
   const response = await client.listClusters();
 
   expect(response.clusters).toHaveLength(2);


### PR DESCRIPTION
Algolia can't ensure consistency between all the 3 hosts when you perform a `waitTask` operation. For this reason, we decided to target a single host ( with bigger timeouts ) to make sure we don't have any kind of flakiness in our common test suite.