### PR TITLE
fix(browse): expose original error from browse request

### DIFF
--- a/packages/client-search/src/__tests__/integration/browsing.test.ts
+++ b/packages/client-search/src/__tests__/integration/browsing.test.ts
@@ -11,8 +11,17 @@ import { TestSuite } from '../../../../client-common/src/__tests__/TestSuite';
 
 const testSuite = new TestSuite('browsing');
 
-test(testSuite.testName, async () => {
-  const index = testSuite.makeIndex();
+let index: ReturnType<typeof testSuite.makeIndex>;
+let browse: (
+  method: (index: SearchIndex) => any,
+  options?: { hitsPerPage?: number }
+) => Promise<{
+  hitsCount: number;
+  batchCount: number;
+}>;
+
+beforeAll(async () => {
+  index = testSuite.makeIndex();
 
   // First lets create the index.
   await index.setSettings({}).wait();
@@ -20,10 +29,7 @@ test(testSuite.testName, async () => {
   // Then, let's create a generic browse function that
   // will take a browseMethod, and get metrics such as
   // the number of retrieved hits and number of batches.
-  const browse = async (
-    method: (index: SearchIndex) => any,
-    options: { hitsPerPage?: number } = {}
-  ) => {
+  browse = async (method, options = {}) => {
     const result = {
       hitsCount: 0,
       batchCount: 0,
@@ -41,102 +47,120 @@ test(testSuite.testName, async () => {
 
     return result;
   };
+});
 
-  // Next, let's create a test case for each browse type, note that
-  // each test case as a specific method, a specific way of browsing,
-  // and also a specific way of reseting the dataset.
+describe.each([
+  [
+    'browseObjects',
+    {
+      method: browseObjects,
+      async withDataset(number: number) {
+        await index.clearObjects();
 
-  const objectsCase = {
-    method: browseObjects,
-    async withDataset(number: number) {
-      await index.clearObjects();
-
-      await index.saveObjects(createFaker().objects(number)).wait();
+        await index.saveObjects(createFaker().objects(number)).wait();
+      },
+      cursorBased: true,
     },
-    cursorBased: true,
-  };
+  ],
+  [
+    'browseRules',
+    {
+      method: browseRules,
+      async withDataset(number: number) {
+        await index.clearRules();
 
-  const rulesCase = {
-    method: browseRules,
-    async withDataset(number: number) {
-      await index.clearRules();
-
-      await index
-        .saveRules(
-          [...Array(number).keys()].map(objectID => ({
-            objectID: objectID.toString(),
-            consequence: { params: { filters: 'brand:OnePlus' } },
-          }))
-        )
-        .wait();
+        await index
+          .saveRules(
+            [...Array(number).keys()].map(objectID => ({
+              objectID: objectID.toString(),
+              consequence: { params: { filters: 'brand:OnePlus' } },
+            }))
+          )
+          .wait();
+      },
+      cursorBased: false,
     },
-    cursorBased: false,
-  };
+  ],
+  [
+    'browseSynonyms',
+    {
+      method: browseSynonyms,
+      async withDataset(number: number) {
+        await index.clearSynonyms();
 
-  const synonymsCase = {
-    method: browseSynonyms,
-    async withDataset(number: number) {
-      await index.clearSynonyms();
-
-      await index
-        .saveSynonyms(
-          [...Array(number).keys()].map(objectID => ({
-            objectID: objectID.toString(),
-            type: 'synonym',
-            synonyms: ['gba', 'gameboy advance', 'game boy advance'],
-          }))
-        )
-        .wait();
+        await index
+          .saveSynonyms(
+            [...Array(number).keys()].map(objectID => ({
+              objectID: objectID.toString(),
+              type: 'synonym',
+              synonyms: ['gba', 'gameboy advance', 'game boy advance'],
+            }))
+          )
+          .wait();
+      },
+      cursorBased: false,
     },
-    cursorBased: false,
-  };
+  ],
+])(`${testSuite.testName}: %s`, (_methodName, testCase) => {
+  test('empty', async () => {
+    await expect(browse(testCase.method)).resolves.toEqual({
+      hitsCount: 0,
+      batchCount: 1,
+    });
+  });
 
-  // Finaly let's start the testing part. For each browse type lets test
-  // it against, and multiple numbers of datasets and conditions.
-  await Promise.all(
-    [objectsCase, synonymsCase, rulesCase].map(async testCase => {
-      await expect(browse(testCase.method)).resolves.toEqual({
-        hitsCount: 0,
+  test('dataset 10', async () => {
+    await testCase.withDataset(10);
+
+    await Promise.all([
+      expect(browse(testCase.method)).resolves.toEqual({
+        hitsCount: 10,
         batchCount: 1,
-      });
+      }),
 
-      await testCase.withDataset(10);
+      expect(browse(testCase.method, { hitsPerPage: 9 })).resolves.toEqual({
+        hitsCount: 10,
+        batchCount: 2,
+      }),
 
-      await Promise.all([
-        expect(browse(testCase.method)).resolves.toEqual({
-          hitsCount: 10,
-          batchCount: 1,
-        }),
+      expect(browse(testCase.method, { hitsPerPage: 10 })).resolves.toEqual({
+        hitsCount: 10,
+        batchCount: testCase.cursorBased ? 1 : 2,
+      }),
 
-        expect(browse(testCase.method, { hitsPerPage: 9 })).resolves.toEqual({
-          hitsCount: 10,
-          batchCount: 2,
-        }),
+      expect(browse(testCase.method, { hitsPerPage: 11 })).resolves.toEqual({
+        hitsCount: 10,
+        batchCount: 1,
+      }),
+    ]);
+  });
 
-        expect(browse(testCase.method, { hitsPerPage: 10 })).resolves.toEqual({
-          hitsCount: 10,
-          batchCount: testCase.cursorBased ? 1 : 2,
-        }),
+  test('dataset 1000', async () => {
+    await testCase.withDataset(1000);
 
-        expect(browse(testCase.method, { hitsPerPage: 11 })).resolves.toEqual({
-          hitsCount: 10,
-          batchCount: 1,
-        }),
-      ]);
+    await Promise.all([
+      expect(browse(testCase.method)).resolves.toEqual({
+        hitsCount: 1000,
+        batchCount: testCase.cursorBased ? 1 : 2,
+      }),
 
-      await testCase.withDataset(1000);
+      expect(browse(testCase.method, { hitsPerPage: 999 })).resolves.toEqual({
+        hitsCount: 1000,
+        batchCount: 2,
+      }),
+    ]);
+  });
 
-      await Promise.all([
-        expect(browse(testCase.method)).resolves.toEqual({
-          hitsCount: 1000,
-          batchCount: testCase.cursorBased ? 1 : 2,
-        }),
-
-        expect(browse(testCase.method, { hitsPerPage: 999 })).resolves.toEqual({
-          hitsCount: 1000,
-          batchCount: 2,
-        }),
-      ]);
-    })
-  );
+  test('error inside browse method', async () => {
+    await expect(
+      testCase.method(index)({
+        unknownParameter: 'fail',
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        message: expect.any(String),
+        name: 'ApiError',
+      })
+    );
+  });
 });

--- a/packages/client-search/src/createBrowsablePromise.ts
+++ b/packages/client-search/src/createBrowsablePromise.ts
@@ -6,43 +6,41 @@ export function createBrowsablePromise<TObject>(
     readonly request: (data: BrowseRequestData) => Readonly<Promise<BrowseResponse<TObject>>>;
   } & BrowseOptions<TObject>
 ): Readonly<Promise<void>> {
-  return new Promise<void>(resolve => {
-    const browse = (data: BrowseRequestData = {}): Promise<void> => {
-      return options.request(data).then(response => {
-        /**
-         * First we send to the developer the
-         * batch retrieved from the API.
-         */
-        if (options.batch !== undefined) {
-          options.batch(response.hits);
-        }
+  const browse = (data: BrowseRequestData): Promise<void> => {
+    return options.request(data).then(response => {
+      /**
+       * First we send to the developer the
+       * batch retrieved from the API.
+       */
+      if (options.batch !== undefined) {
+        options.batch(response.hits);
+      }
 
-        /**
-         * Then, we ask to the browse concrete implementation
-         * if we should stop browsing. As example, the `browseObjects`
-         * method will stop if the cursor is not present on the response.
-         */
-        if (options.shouldStop(response)) {
-          return resolve();
-        }
+      /**
+       * Then, we ask to the browse concrete implementation
+       * if we should stop browsing. As example, the `browseObjects`
+       * method will stop if the cursor is not present on the response.
+       */
+      if (options.shouldStop(response)) {
+        return undefined;
+      }
 
-        /**
-         * Finally, if the response contains a cursor, we browse to the next
-         * batch using that same cursor. Otherwise, we just use the traditional
-         * browsing using the page element.
-         */
-        if (response.cursor) {
-          return browse({
-            cursor: response.cursor,
-          });
-        }
-
+      /**
+       * Finally, if the response contains a cursor, we browse to the next
+       * batch using that same cursor. Otherwise, we just use the traditional
+       * browsing using the page element.
+       */
+      if (response.cursor) {
         return browse({
-          page: (data.page || 0) + 1,
+          cursor: response.cursor,
         });
-      });
-    };
+      }
 
-    return browse();
-  });
+      return browse({
+        page: (data.page || 0) + 1,
+      });
+    });
+  };
+
+  return browse({});
 }

--- a/scripts/prepare-test-unit.sh
+++ b/scripts/prepare-test-unit.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 kill -9 `ps aux | grep test-server-for-timeouts | awk '{print $2}'` 2> /dev/null || : && node scripts/test-server-for-timeouts.js &


### PR DESCRIPTION
Wrapping the original function in a new Promise swallowed its errors, and thus if there was some kind of error, you'd get an "unhandled promise" error like this:

```
(node:52050) UnhandledPromiseRejectionWarning: #<Object>
(node:52050) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:52050) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

instead of something like:


```js
{
  name: 'ApiError',
  message: 'Index prod_dictionaries does not exist',
  status: 404,
  transporterStackTrace: [
    {
      request: [Object],
      response: [Object],
      host: [Object],
      triesLeft: 3
    }
  ]
}
```

<details>
<summary>code to get that error</summary>

```
const fs = require('fs')
const algoliasearch = require('algoliasearch')
const client = algoliasearch('xxx', 'xxx')
const index = client.initIndex('xxx_invalid_index')
let hits = []
index
  .browseObjects({
    batch: objects => (hits = hits.concat(objects)),
  })
  .then(() => {
    console.log('Finished!')
    console.log('We got %d hits', hits.length)
    fs.writeFile('browse.json', JSON.stringify(hits, null, 2), 'utf-8', err => {
      if (err) throw err
      console.log('Your index has been exported!')
    })
  })
  .catch(e => {
    console.log(e)
  })
```

</details>