### PR TITLE
test(unit): don't commit snapshots on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ coverage
 node_modules
 dist
 .vscode
-*.test.ts.snap
 *.umd.js

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:lint": "eslint . --ext .js,.ts",
     "test:locally": "lerna clean --yes && yarn lint && yarn test:types && yarn test:unit",
     "test:types": "yarn tsc",
-    "test:unit": "./scripts/prepare-test-unit.sh && lerna clean --yes && jest --verbose --updateSnapshot",
+    "test:unit": "./scripts/prepare-test-unit.sh && lerna clean --yes && jest --verbose",
     "update": "rm -rf node_modules && rm -f yarn.lock && lerna clean --yes && yarn install"
   },
   "husky": {

--- a/packages/cache-browser-local-storage/src/__tests__/unit/browser-local-storage-cache.test.ts
+++ b/packages/cache-browser-local-storage/src/__tests__/unit/browser-local-storage-cache.test.ts
@@ -24,7 +24,11 @@ describe('browser local storage cache', () => {
       await cache.get({ key: 'foo' }, defaultValue, {
         miss: () => Promise.resolve(missMock()),
       })
-    ).toMatchSnapshot({ bar: 1 });
+    ).toMatchInlineSnapshot(`
+      Object {
+        "bar": 1,
+      }
+    `);
 
     expect(missMock.mock.calls.length).toBe(1);
 

--- a/packages/cache-in-memory/src/__tests__/unit/in-memory-cache.test.ts
+++ b/packages/cache-in-memory/src/__tests__/unit/in-memory-cache.test.ts
@@ -12,7 +12,11 @@ describe('in memory cache', () => {
       await cache.get({ key: 'foo' }, defaultValue, {
         miss: () => Promise.resolve(missMock()),
       })
-    ).toMatchSnapshot({ bar: 1 });
+    ).toMatchInlineSnapshot(`
+      Object {
+        "bar": 1,
+      }
+    `);
 
     await cache.set({ key: 'foo' }, { foo: 2 });
 


### PR DESCRIPTION
While on local development, it might be useful to update the snapshot all the time,  on CI that could be a hidden failure.

We have two tests that updated all the time their snapshot.

On CI that looks like this:

```
Snapshot Summary
 › 2 snapshots written from 2 **** suites.

Test Suites: 1 failed, 94 passed, 95 total
Tests:       1 failed, 317 passed, 318 total
Snapshots:   2 written, 1 passed, 3 total
Time:        63.027s
Ran all **** suites in 3 projects.
```

I've updated those two tests (which were using snapshots invalidly) to be inline snapshots now (could also be toEqual), and removed the .snap rule from gitignore (they're supposed to be tracked)