### PR TITLE
chore(fixes-secured-api-keys-test): reuses the same hosts on the test

### DIFF
--- a/packages/client-search/src/__tests__/integration/secured-api-keys.test.ts
+++ b/packages/client-search/src/__tests__/integration/secured-api-keys.test.ts
@@ -17,7 +17,9 @@ test(testSuite.testName, async () => {
 
   await expect(
     testSuite
-      .algoliasearch(index1.appId, securedApiKey)
+      .algoliasearch(index1.appId, securedApiKey, {
+        hosts: client.transporter.hosts,
+      })
       .initIndex(index1.indexName)
       .search('')
   ).resolves.toMatchObject({


### PR DESCRIPTION
This pull request addresses the reuse of hosts on the secured api keys test. 