### PR TITLE
fix(types): remove readonly from responses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,6 @@ const { resolve } = require("path");
 const PACKAGE_DIR = "./packages";
 
 const noExtraneousOverrides = require("./scripts/packages").map(package => {
-
   return {
     files: [`${PACKAGE_DIR}/${package}/**/*`],
     rules: {
@@ -119,6 +118,12 @@ module.exports = {
         "functional/prefer-readonly-type": 0,
         "sonarjs/no-duplicate-string": 0,
         "jest/expect-expect": 0
+      }
+    },
+    {
+      files: ["**/src/types/*Response.ts"],
+      rules: {
+        "functional/prefer-readonly-type": 0
       }
     }
   ],

--- a/packages/client-analytics/src/types/AddABTestResponse.ts
+++ b/packages/client-analytics/src/types/AddABTestResponse.ts
@@ -2,15 +2,15 @@ export type AddABTestResponse = {
   /**
    * The ab test unique identifier.
    */
-  readonly abTestID: number;
+  abTestID: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The index name where the ab test is attached to.
    */
-  readonly index: string;
+  index: string;
 };

--- a/packages/client-analytics/src/types/DeleteABTestResponse.ts
+++ b/packages/client-analytics/src/types/DeleteABTestResponse.ts
@@ -2,15 +2,15 @@ export type DeleteABTestResponse = {
   /**
    * The ab test unique identifier.
    */
-  readonly abTestID: number;
+  abTestID: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The index name where the ab test was attached to.
    */
-  readonly index: string;
+  index: string;
 };

--- a/packages/client-analytics/src/types/GetABTestResponse.ts
+++ b/packages/client-analytics/src/types/GetABTestResponse.ts
@@ -4,41 +4,41 @@ export type GetABTestResponse = {
   /**
    * The ab test name.
    */
-  readonly name: string;
+  name: string;
 
   /**
    * The ab test status.
    */
-  readonly status: string;
+  status: string;
 
   /**
    * The ab test list of variants.
    */
-  readonly variants: readonly VariantResponse[];
+  variants: VariantResponse[];
 
   /**
    * The ab test end date, if any.
    */
-  readonly endAt: string;
+  endAt: string;
 
   /**
    * The ab test created date, if any.
    */
-  readonly createdAt: string;
+  createdAt: string;
 
   /**
    * The ab test unique identifier.
    */
-  readonly abTestID: number;
+  abTestID: number;
 
   /**
    * The ab test significance based on click data. Should be > 0.95 to be considered significant - no matter which variant is winning.
    */
-  readonly clickSignificance: number;
+  clickSignificance: number;
 
   /**
    *
    * The ab test significance based on conversion data. Should be > 0.95 to be considered significant - no matter which variant is winning.
    */
-  readonly conversionSignificance: number;
+  conversionSignificance: number;
 };

--- a/packages/client-analytics/src/types/GetABTestsResponse.ts
+++ b/packages/client-analytics/src/types/GetABTestsResponse.ts
@@ -4,15 +4,15 @@ export type GetABTestsResponse = {
   /**
    * The number of ab tests within this response.
    */
-  readonly count: number;
+  count: number;
 
   /**
    * The total of ab tests.
    */
-  readonly total: number;
+  total: number;
 
   /**
    * The list of ab tests.
    */
-  readonly abtests: readonly GetABTestResponse[] | null;
+  abtests: GetABTestResponse[] | null;
 };

--- a/packages/client-analytics/src/types/StopABTestResponse.ts
+++ b/packages/client-analytics/src/types/StopABTestResponse.ts
@@ -2,15 +2,15 @@ export type StopABTestResponse = {
   /**
    * The ab test unique identifier.
    */
-  readonly abTestID: number;
+  abTestID: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The index name where the ab test is attached to.
    */
-  readonly index: string;
+  index: string;
 };

--- a/packages/client-analytics/src/types/VariantResponse.ts
+++ b/packages/client-analytics/src/types/VariantResponse.ts
@@ -6,47 +6,47 @@ export type VariantResponse = Variant & {
   /**
    * Average click position for the variant.
    */
-  readonly averageClickPostion?: number;
+  averageClickPostion?: number;
 
   /**
    * Distinct click count for the variant.
    */
-  readonly clickCount?: number;
+  clickCount?: number;
 
   /**
    * Click through rate for the variant.
    */
-  readonly clickThroughRate?: number;
+  clickThroughRate?: number;
 
   /**
    * Click through rate for the variant.
    */
-  readonly conversionCount?: number;
+  conversionCount?: number;
 
   /**
    * Distinct conversion count for the variant.
    */
-  readonly conversionRate?: number;
+  conversionRate?: number;
 
   /**
    * No result count.
    */
-  readonly noResultCount?: number;
+  noResultCount?: number;
 
   /**
    * Search count.
    */
-  readonly searchCount?: number;
+  searchCount?: number;
 
   /**
    * User count.
    */
-  readonly userCount?: number;
+  userCount?: number;
 
   /**
    * The search parameters.
    *
    * @todo Handle this search options type.
    */
-  readonly customSearchParameters?: SearchOptions;
+  customSearchParameters?: SearchOptions;
 };

--- a/packages/client-recommendation/src/types/GetPersonalizationStrategyResponse.ts
+++ b/packages/client-recommendation/src/types/GetPersonalizationStrategyResponse.ts
@@ -2,22 +2,22 @@ export type GetPersonalizationStrategyResponse = {
   /**
    * Events scoring
    */
-  readonly eventsScoring: ReadonlyArray<{
-    readonly eventName: string;
-    readonly eventType: string;
-    readonly score: number;
+  eventsScoring: Array<{
+    eventName: string;
+    eventType: string;
+    score: number;
   }>;
 
   /**
    * Facets scoring
    */
-  readonly facetsScoring: ReadonlyArray<{
-    readonly facetName: string;
-    readonly score: number;
+  facetsScoring: Array<{
+    facetName: string;
+    score: number;
   }>;
 
   /**
    * Personalization impact
    */
-  readonly personalizationImpact: number;
+  personalizationImpact: number;
 };

--- a/packages/client-recommendation/src/types/SetPersonalizationStrategyResponse.ts
+++ b/packages/client-recommendation/src/types/SetPersonalizationStrategyResponse.ts
@@ -2,10 +2,10 @@ export type SetPersonalizationStrategyResponse = {
   /**
    * The status code.
    */
-  readonly status?: number;
+  status?: number;
 
   /**
    * The message.
    */
-  readonly message: string;
+  message: string;
 };

--- a/packages/client-search/src/types/AddApiKeyResponse.ts
+++ b/packages/client-search/src/types/AddApiKeyResponse.ts
@@ -2,10 +2,10 @@ export type AddApiKeyResponse = {
   /**
    * The returned api key.
    */
-  readonly key: string;
+  key: string;
 
   /**
    * Date of creation of the api key.
    */
-  readonly createdAt: string;
+  createdAt: string;
 };

--- a/packages/client-search/src/types/AssignUserIDResponse.ts
+++ b/packages/client-search/src/types/AssignUserIDResponse.ts
@@ -2,5 +2,5 @@ export type AssignUserIDResponse = {
   /**
    * Date of creation of the userId.
    */
-  readonly createdAt: string;
+  createdAt: string;
 };

--- a/packages/client-search/src/types/AssignUserIDsResponse.ts
+++ b/packages/client-search/src/types/AssignUserIDsResponse.ts
@@ -2,5 +2,5 @@ export type AssignUserIDsResponse = {
   /**
    * Date of creation of the userId
    */
-  readonly createdAt: string;
+  createdAt: string;
 };

--- a/packages/client-search/src/types/BatchResponse.ts
+++ b/packages/client-search/src/types/BatchResponse.ts
@@ -2,10 +2,10 @@ export type BatchResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The object ids created/updated by the batch request.
    */
-  readonly objectIDs: readonly string[];
+  objectIDs: string[];
 };

--- a/packages/client-search/src/types/BrowseResponse.ts
+++ b/packages/client-search/src/types/BrowseResponse.ts
@@ -4,10 +4,10 @@ export type BrowseResponse<TObject> = {
   /**
    * The hits per page.
    */
-  readonly hits: ReadonlyArray<TObject & ObjectWithObjectID>;
+  hits: Array<TObject & ObjectWithObjectID>;
 
   /**
    * The cursor used for iterate on the next page.
    */
-  readonly cursor?: string;
+  cursor?: string;
 };

--- a/packages/client-search/src/types/ChunkedBatchResponse.ts
+++ b/packages/client-search/src/types/ChunkedBatchResponse.ts
@@ -2,10 +2,10 @@ export type ChunkedBatchResponse = {
   /**
    * The operations task ids. May be used to perform a wait task.
    */
-  readonly taskIDs: readonly number[];
+  taskIDs: number[];
 
   /**
    * The object ids created/updated/deleted by the multiple requests.
    */
-  readonly objectIDs: readonly string[];
+  objectIDs: string[];
 };

--- a/packages/client-search/src/types/DeleteApiKeyResponse.ts
+++ b/packages/client-search/src/types/DeleteApiKeyResponse.ts
@@ -2,5 +2,5 @@ export type DeleteApiKeyResponse = {
   /**
    * The date when the api key was deleted.
    */
-  readonly deletedAt: string;
+  deletedAt: string;
 };

--- a/packages/client-search/src/types/DeleteResponse.ts
+++ b/packages/client-search/src/types/DeleteResponse.ts
@@ -2,5 +2,5 @@ export type DeleteResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/FindObjectResponse.ts
+++ b/packages/client-search/src/types/FindObjectResponse.ts
@@ -4,15 +4,15 @@ export type FindObjectResponse<TObject> = {
   /**
    * The found object.
    */
-  readonly object: TObject & ObjectWithObjectID;
+  object: TObject & ObjectWithObjectID;
 
   /**
    * The position where the object was found.
    */
-  readonly position: number;
+  position: number;
 
   /**
    * The page where the object was found.
    */
-  readonly page: number;
+  page: number;
 };

--- a/packages/client-search/src/types/GetApiKeyResponse.ts
+++ b/packages/client-search/src/types/GetApiKeyResponse.ts
@@ -2,51 +2,51 @@ export type GetApiKeyResponse = {
   /**
    * A Unix timestamp used to define the expiration date of the API key.
    */
-  readonly value: string;
+  value: string;
 
   /**
    * Date of creation.
    */
-  readonly createdAt: string;
+  createdAt: string;
 
   /**
    * List of permissions the key contains.
    */
-  readonly acl: readonly string[];
+  acl: string[];
 
   /**
    * A Unix timestamp used to define the expiration date of the API key.
    */
-  readonly validity: number;
+  validity: number;
 
   /**
    * Specify the maximum number of hits this API key can retrieve in one call.
    * This parameter can be used to protect you from attempts at retrieving your entire index contents by massively querying the index.
    */
-  readonly maxHitsPerQuery?: number;
+  maxHitsPerQuery?: number;
 
   /**
    * Specify the maximum number of API calls allowed from an IP address per hour. Each time an API call is performed with this key, a check is performed.
    */
-  readonly maxQueriesPerIPPerHour?: number;
+  maxQueriesPerIPPerHour?: number;
 
   /**
    * Specify the list of targeted indices. You can target all indices starting with a prefix or ending with a suffix using the ‘*’ character.
    */
-  readonly indexes?: readonly string[];
+  indexes?: string[];
 
   /**
    * Specify the list of referers. You can target all referers starting with a prefix, ending with a suffix using the ‘*’ character.
    */
-  readonly referers?: readonly string[];
+  referers?: string[];
 
   /**
    * Specify the list of query parameters. You can force the query parameters for a query using the url string format.
    */
-  readonly queryParameters?: string;
+  queryParameters?: string;
 
   /**
    * Specify a description of the API key. Used for informative purposes only. It has impact on the functionality of the API key.
    */
-  readonly description?: string;
+  description?: string;
 };

--- a/packages/client-search/src/types/GetLogsResponse.ts
+++ b/packages/client-search/src/types/GetLogsResponse.ts
@@ -4,5 +4,5 @@ export type GetLogsResponse = {
   /**
    * The list of logs.
    */
-  readonly logs: readonly Log[];
+  logs: Log[];
 };

--- a/packages/client-search/src/types/GetObjectsResponse.ts
+++ b/packages/client-search/src/types/GetObjectsResponse.ts
@@ -4,5 +4,5 @@ export type GetObjectsResponse<TObject> = {
   /**
    * The list of results.
    */
-  readonly results: ReadonlyArray<TObject & ObjectWithObjectID>;
+  results: Array<TObject & ObjectWithObjectID>;
 };

--- a/packages/client-search/src/types/GetTopUserIDsResponse.ts
+++ b/packages/client-search/src/types/GetTopUserIDsResponse.ts
@@ -4,5 +4,5 @@ export type GetTopUserIDsResponse = {
   /**
    * Mapping of cluster names to top users.
    */
-  readonly topUsers: Readonly<Record<string, readonly UserIDResponse[]>>;
+  topUsers: Record<string, UserIDResponse[]>;
 };

--- a/packages/client-search/src/types/HasPendingMappingsResponse.ts
+++ b/packages/client-search/src/types/HasPendingMappingsResponse.ts
@@ -2,10 +2,10 @@ export type HasPendingMappingsResponse = {
   /**
    * If there is any clusters with pending mapping state.
    */
-  readonly pending: boolean;
+  pending: boolean;
 
   /**
    * Describe cluster pending (migrating, creating, deleting) mapping state.
    */
-  readonly clusters?: { readonly [key: string]: readonly string[] };
+  clusters?: { [key: string]: string[] };
 };

--- a/packages/client-search/src/types/IndexOperationResponse.ts
+++ b/packages/client-search/src/types/IndexOperationResponse.ts
@@ -2,5 +2,5 @@ export type IndexOperationResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/ListApiKeysResponse.ts
+++ b/packages/client-search/src/types/ListApiKeysResponse.ts
@@ -4,5 +4,5 @@ export type ListApiKeysResponse = {
   /**
    * List of keys
    */
-  readonly keys: readonly GetApiKeyResponse[];
+  keys: GetApiKeyResponse[];
 };

--- a/packages/client-search/src/types/ListClustersResponse.ts
+++ b/packages/client-search/src/types/ListClustersResponse.ts
@@ -4,5 +4,5 @@ export type ListClustersResponse = {
   /**
    * List of clusters.
    */
-  readonly clusters: readonly Cluster[];
+  clusters: Cluster[];
 };

--- a/packages/client-search/src/types/ListIndicesResponse.ts
+++ b/packages/client-search/src/types/ListIndicesResponse.ts
@@ -4,10 +4,10 @@ export type ListIndicesResponse = {
   /**
    * Number of pages
    */
-  readonly nbPages: number;
+  nbPages: number;
 
   /**
    * List of index response
    */
-  readonly items: readonly Indice[];
+  items: Indice[];
 };

--- a/packages/client-search/src/types/ListUserIDsResponse.ts
+++ b/packages/client-search/src/types/ListUserIDsResponse.ts
@@ -4,5 +4,5 @@ export type ListUserIDsResponse = {
   /**
    * List of users id.
    */
-  readonly userIDs: readonly UserIDResponse[];
+  userIDs: UserIDResponse[];
 };

--- a/packages/client-search/src/types/MultipleBatchResponse.ts
+++ b/packages/client-search/src/types/MultipleBatchResponse.ts
@@ -2,10 +2,10 @@ export type MultipleBatchResponse = {
   /**
    * The list of object ids.
    */
-  readonly objectIDs: readonly string[];
+  objectIDs: string[];
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: Readonly<Record<string, number>>;
+  taskID: Record<string, number>;
 };

--- a/packages/client-search/src/types/MultipleGetObjectsResponse.ts
+++ b/packages/client-search/src/types/MultipleGetObjectsResponse.ts
@@ -4,5 +4,5 @@ export type MultipleGetObjectsResponse<TObject> = {
   /**
    * The list of objects.
    */
-  readonly results: ReadonlyArray<TObject & ObjectWithObjectID>;
+  results: Array<TObject & ObjectWithObjectID>;
 };

--- a/packages/client-search/src/types/MultipleQueriesResponse.ts
+++ b/packages/client-search/src/types/MultipleQueriesResponse.ts
@@ -4,5 +4,5 @@ export type MultipleQueriesResponse<TObject> = {
   /**
    * The list of results.
    */
-  readonly results: ReadonlyArray<SearchResponse<TObject & ObjectWithObjectID>>;
+  results: Array<SearchResponse<TObject & ObjectWithObjectID>>;
 };

--- a/packages/client-search/src/types/PartialUpdateObjectResponse.ts
+++ b/packages/client-search/src/types/PartialUpdateObjectResponse.ts
@@ -2,10 +2,10 @@ export type PartialUpdateObjectResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The object id updated.
    */
-  readonly objectID: string;
+  objectID: string;
 };

--- a/packages/client-search/src/types/RemoveUserIDResponse.ts
+++ b/packages/client-search/src/types/RemoveUserIDResponse.ts
@@ -2,5 +2,5 @@ export type RemoveUserIDResponse = {
   /**
    * When the given `userID` got removed.
    */
-  readonly deletedAt: string;
+  deletedAt: string;
 };

--- a/packages/client-search/src/types/RestoreApiKeyResponse.ts
+++ b/packages/client-search/src/types/RestoreApiKeyResponse.ts
@@ -2,5 +2,5 @@ export type RestoreApiKeyResponse = {
   /**
    * Restoration date of the API key.
    */
-  readonly createdAt: string;
+  createdAt: string;
 };

--- a/packages/client-search/src/types/SaveObjectResponse.ts
+++ b/packages/client-search/src/types/SaveObjectResponse.ts
@@ -2,10 +2,10 @@ export type SaveObjectResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * The object id saved.
    */
-  readonly objectID: string;
+  objectID: string;
 };

--- a/packages/client-search/src/types/SaveRuleResponse.ts
+++ b/packages/client-search/src/types/SaveRuleResponse.ts
@@ -2,10 +2,10 @@ export type SaveRuleResponse = {
   /**
    * When the given rules got saved.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/SaveRulesResponse.ts
+++ b/packages/client-search/src/types/SaveRulesResponse.ts
@@ -2,10 +2,10 @@ export type SaveRulesResponse = {
   /**
    * When the given rules got saved.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/SaveSynonymResponse.ts
+++ b/packages/client-search/src/types/SaveSynonymResponse.ts
@@ -2,10 +2,10 @@ export type SaveSynonymResponse = {
   /**
    * When the given synonyms got saved.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/SaveSynonymsResponse.ts
+++ b/packages/client-search/src/types/SaveSynonymsResponse.ts
@@ -2,10 +2,10 @@ export type SaveSynonymsResponse = {
   /**
    * When the given synonyms got saved.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 };

--- a/packages/client-search/src/types/SearchForFacetValuesResponse.ts
+++ b/packages/client-search/src/types/SearchForFacetValuesResponse.ts
@@ -4,15 +4,15 @@ export type SearchForFacetValuesResponse = {
   /**
    * The list of facet hits.
    */
-  readonly facetHits: readonly FacetHit[];
+  facetHits: FacetHit[];
 
   /**
    * The exhaustive facets count.
    */
-  readonly exhaustiveFacetsCount: boolean;
+  exhaustiveFacetsCount: boolean;
 
   /**
    * The time that the API toke the process the request.
    */
-  readonly processingTimeMS?: number;
+  processingTimeMS?: number;
 };

--- a/packages/client-search/src/types/SearchResponse.ts
+++ b/packages/client-search/src/types/SearchResponse.ts
@@ -6,27 +6,27 @@ export type SearchResponse<TObject = {}> = {
    *
    * Hits are ordered according to the ranking or sorting of the index being queried.
    */
-  readonly hits: ReadonlyArray<TObject & ObjectWithObjectID>;
+  hits: Array<TObject & ObjectWithObjectID>;
 
   /**
    * Index of the current page (zero-based).
    */
-  readonly page: number;
+  page: number;
 
   /**
    * Number of hits returned (used only with offset)
    */
-  readonly length?: number;
+  length?: number;
 
   /**
    * The offset of the first hit to returned.
    */
-  readonly offset?: number;
+  offset?: number;
 
   /**
    * Number of hits matched by the query.
    */
-  readonly nbHits: number;
+  nbHits: number;
 
   /**
    * Number of pages returned.
@@ -34,17 +34,17 @@ export type SearchResponse<TObject = {}> = {
    * Calculation is based on the total number of hits (nbHits) divided by the
    * number of hits per page (hitsPerPage), rounded up to the nearest integer.
    */
-  readonly nbPages: number;
+  nbPages: number;
 
   /**
    * Maximum number of hits returned per page.
    */
-  readonly hitsPerPage: number;
+  hitsPerPage: number;
 
   /**
    * Time the server took to process the request, in milliseconds. This does not include network time.
    */
-  readonly processingTimeMS: number;
+  processingTimeMS: number;
 
   /**
    * Whether the nbHits is exhaustive (true) or approximate (false).
@@ -52,46 +52,44 @@ export type SearchResponse<TObject = {}> = {
    * An approximation is done when the query takes more than 50ms to be
    * processed (this can happen when using complex filters on millions on records).
    */
-  readonly exhaustiveNbHits: boolean;
+  exhaustiveNbHits: boolean;
 
   /**
    * Whether the facet count is exhaustive (true) or approximate (false).
    */
-  readonly exhaustiveFacetsCount?: boolean;
+  exhaustiveFacetsCount?: boolean;
 
   /**
    * A mapping of each facet name to the corresponding facet counts.
    */
-  readonly facets?: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  facets?: Record<string, Record<string, number>>;
 
   /**
    * Statistics for numerical facets.
    */
-  readonly facetsStats?: Readonly<
-    Record<
-      string,
-      {
-        /**
-         * The minimum value in the result set.
-         */
-        readonly min: number;
+  facetsStats?: Record<
+    string,
+    {
+      /**
+       * The minimum value in the result set.
+       */
+      min: number;
 
-        /**
-         * The maximum value in the result set.
-         */
-        readonly max: number;
+      /**
+       * The maximum value in the result set.
+       */
+      max: number;
 
-        /**
-         * The average facet value in the result set.
-         */
-        readonly avg: number;
+      /**
+       * The average facet value in the result set.
+       */
+      avg: number;
 
-        /**
-         * The sum of all values in the result set.
-         */
-        readonly sum: number;
-      }
-    >
+      /**
+       * The sum of all values in the result set.
+       */
+      sum: number;
+    }
   >;
 
   /**
@@ -99,115 +97,115 @@ export type SearchResponse<TObject = {}> = {
    *
    * An empty query can be used to fetch all records.
    */
-  readonly query: string;
+  query: string;
 
   /**
    * A markup text indicating which parts of the original query have been removed in order to retrieve a non-empty result set.
    */
-  readonly queryAfterRemoval?: string;
+  queryAfterRemoval?: string;
 
   /**
    * A url-encoded string of all search parameters.
    */
-  readonly params: string;
+  params: string;
 
   /**
    * Unique identifier of the search query, to be sent in Insights methods. This identifier links events back to the search query it represents.
    *
    * Returned only if clickAnalytics is true.
    */
-  readonly queryID?: string;
+  queryID?: string;
 
   /**
    * Used to return warnings about the query.
    */
-  readonly message?: string;
+  message?: string;
 
   /**
    * The computed geo location.
    *
    * Format: "lat,lng", where the latitude and longitude are expressed as decimal floating point number.
    */
-  readonly aroundLatLng?: string;
+  aroundLatLng?: string;
 
   /**
    * The automatically computed radius.
    */
-  readonly automaticRadius?: string;
+  automaticRadius?: string;
 
   /**
    * Actual host name of the server that processed the request.
    *
    * Our DNS supports automatic failover and load balancing, so this may differ from the host name used in the request.
    */
-  readonly serverUsed?: string;
+  serverUsed?: string;
 
   /**
    * Index name used for the query.
    */
-  readonly index?: string;
+  index?: string;
 
   /**
    * Index name used for the query. In case of AB test, the index targetted isn’t always the index used by the query.
    */
-  readonly indexUsed?: string;
+  indexUsed?: string;
 
   /**
    * In case of AB test, reports the variant ID used. The variant ID is the position in the array of variants (starting at 1).
    */
-  readonly abTestVariantID?: number;
+  abTestVariantID?: number;
 
   /**
    * The query string that will be searched, after normalization.
    */
-  readonly parsedQuery?: string;
+  parsedQuery?: string;
 
   /**
    * Custom user data.
    */
-  readonly userData?: any;
+  userData?: any;
 
   /**
    * Rules applied to the query.
    */
-  readonly appliedRules?: ReadonlyArray<Readonly<Record<string, any>>>;
+  appliedRules?: Array<Record<string, any>>;
 
   /**
    * The explanation of the decompounding at query time.
    */
-  readonly explain?: {
+  explain?: {
     /**
      * The explain query match.
      */
-    readonly match: {
+    match: {
       /**
        * The explain query match alternatives.
        */
-      readonly alternatives: ReadonlyArray<{
+      alternatives: Array<{
         /**
          * The alternative type.
          */
-        readonly types: readonly string[];
+        types: string[];
 
         /**
          * The list of alternative words.
          */
-        readonly words: readonly string[];
+        words: string[];
 
         /**
          * The number of typos.
          */
-        readonly typos: number;
+        typos: number;
 
         /**
          * The offset.
          */
-        readonly offset: number;
+        offset: number;
 
         /**
          * The length.
          */
-        readonly length: number;
+        length: number;
       }>;
     };
 
@@ -215,6 +213,6 @@ export type SearchResponse<TObject = {}> = {
      * Query parameter reporting. Parameters are reported
      * as a JSON object with one field per parameter.
      */
-    readonly params?: Readonly<Record<string, any>>;
+    params?: Record<string, any>;
   };
 };

--- a/packages/client-search/src/types/SearchSynonymsResponse.ts
+++ b/packages/client-search/src/types/SearchSynonymsResponse.ts
@@ -4,10 +4,10 @@ export type SearchSynonymsResponse = {
   /**
    * The list of synonyms.
    */
-  readonly hits: readonly Synonym[];
+  hits: Synonym[];
 
   /**
    * The number of synonyms on the list.
    */
-  readonly nbHits: number;
+  nbHits: number;
 };

--- a/packages/client-search/src/types/SearchUserIDsResponse.ts
+++ b/packages/client-search/src/types/SearchUserIDsResponse.ts
@@ -4,25 +4,25 @@ export type SearchUserIDsResponse<> = {
   /**
    * List of userID matching the query.
    */
-  readonly hits: readonly UserIDResponse[];
+  hits: UserIDResponse[];
 
   /**
    * Current page.
    */
-  readonly page: number;
+  page: number;
 
   /**
    * Number of userIDs matching the query.
    */
-  readonly nbHits: number;
+  nbHits: number;
 
   /**
    * Number of hits retrieved per page.
    */
-  readonly hitsPerPage: number;
+  hitsPerPage: number;
 
   /**
    * Timestamp of the last update of the index.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 };

--- a/packages/client-search/src/types/SetSettingsResponse.ts
+++ b/packages/client-search/src/types/SetSettingsResponse.ts
@@ -2,10 +2,10 @@ export type SetSettingsResponse = {
   /**
    * The operation task id. May be used to perform a wait task.
    */
-  readonly taskID: number;
+  taskID: number;
 
   /**
    * When the settings got updated.
    */
-  readonly updatedAt: number;
+  updatedAt: number;
 };

--- a/packages/client-search/src/types/TaskStatusResponse.ts
+++ b/packages/client-search/src/types/TaskStatusResponse.ts
@@ -3,10 +3,10 @@ export type TaskStatusResponse = {
    * The operation status. When the value is `published` the
    * operation is completed.
    */
-  readonly status: string;
+  status: string;
 
   /**
    * If the operation is pending.
    */
-  readonly pendingTask: boolean;
+  pendingTask: boolean;
 };

--- a/packages/client-search/src/types/UpdateApiKeyResponse.ts
+++ b/packages/client-search/src/types/UpdateApiKeyResponse.ts
@@ -2,10 +2,10 @@ export type UpdateApiKeyResponse = {
   /**
    * The api key.
    */
-  readonly key: string;
+  key: string;
 
   /**
    * Date of update
    */
-  readonly updatedAt: string;
+  updatedAt: string;
 };

--- a/packages/client-search/src/types/UserIDResponse.ts
+++ b/packages/client-search/src/types/UserIDResponse.ts
@@ -2,20 +2,20 @@ export type UserIDResponse = {
   /**
    * userID of the user.
    */
-  readonly userID: string;
+  userID: string;
 
   /**
    * Cluster on which the user is assigned
    */
-  readonly clusterName: string;
+  clusterName: string;
 
   /**
    * Number of records belonging to the user.
    */
-  readonly nbRecords: number;
+  nbRecords: number;
 
   /**
    * Data size used by the user.
    */
-  readonly dataSize: number;
+  dataSize: number;
 };

--- a/packages/requester-common/src/types/Response.ts
+++ b/packages/requester-common/src/types/Response.ts
@@ -2,15 +2,15 @@ export type Response = {
   /**
    * The raw response from the server.
    */
-  readonly content: string;
+  content: string;
 
   /**
    * If the request timeouted.
    */
-  readonly isTimedOut: boolean;
+  isTimedOut: boolean;
 
   /**
    * The http status code.
    */
-  readonly status: number;
+  status: number;
 };


### PR DESCRIPTION
## Description

This closes #1064 by removing all `readonly` attributes from the response types.

## How

- Ignore the rule `functional/prefer-readonly-type` in all `*Response.ts` files
- Remove the `Readonly<>` and `ReadonlyArray<>` types