### PR TITLE
chore(mcm): fixes user string length

### DIFF
--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -131,7 +131,7 @@ export class TestSuite {
     if (jobNumber) {
       return `${environment}_${nodeVersion}_${jobNumber}`;
     } else if (user) {
-      return `${environment}_${nodeVersion}_${user}`;
+      return `${environment}_${nodeVersion}_${user.substring(0, 5)}`;
     }
 
     return `${environment}_${nodeVersion}_unknown`;


### PR DESCRIPTION
UserID could be bigger than expected resulting in a reject from the engine. We shortened it to 5 characters.