### PR TITLE
fix(types): Log types

### DIFF
--- a/packages/client-common/src/__tests__/helpers.ts
+++ b/packages/client-common/src/__tests__/helpers.ts
@@ -3,3 +3,11 @@ import { WaitablePromise } from '..';
 export function waitResponses(responses: Array<Readonly<WaitablePromise<any>>>) {
   return Promise.all(responses.map(response => response.wait()));
 }
+
+export type KeysOfType<TType, TRequiredType> = {
+  [TKey in keyof TType]: TType[TKey] extends TRequiredType ? TKey : never;
+}[keyof TType];
+export type RequiredKeys<TType> = Exclude<
+  KeysOfType<TType, Exclude<TType[keyof TType], undefined>>,
+  undefined
+>;

--- a/packages/client-search/src/__tests__/integration/get-logs.test.ts
+++ b/packages/client-search/src/__tests__/integration/get-logs.test.ts
@@ -1,3 +1,5 @@
+import { Log } from '../..';
+import { RequiredKeys } from '../../../../client-common/src/__tests__/helpers';
 import { TestSuite } from '../../../../client-common/src/__tests__/TestSuite';
 
 const testSuite = new TestSuite('get_logs');
@@ -15,5 +17,19 @@ test(testSuite.testName, async () => {
     type: 'all',
   });
 
-  await expect(getLogsResponse.logs).toHaveLength(2);
+  expect(getLogsResponse.logs).toHaveLength(2);
+  const keys: Array<RequiredKeys<Log>> = [
+    'timestamp',
+    'method',
+    'answer_code',
+    'query_body',
+    'answer',
+    'url',
+    'ip',
+    'sha1',
+    'query_headers',
+    'nb_api_calls',
+    'processing_time_ms',
+  ];
+  expect(Object.keys(getLogsResponse.logs[0])).toEqual(expect.arrayContaining(keys));
 });

--- a/packages/client-search/src/__tests__/integration/get-logs.test.ts
+++ b/packages/client-search/src/__tests__/integration/get-logs.test.ts
@@ -28,7 +28,6 @@ test(testSuite.testName, async () => {
     'ip',
     'sha1',
     'query_headers',
-    'nb_api_calls',
     'processing_time_ms',
   ];
   expect(Object.keys(getLogsResponse.logs[0])).toEqual(expect.arrayContaining(keys));

--- a/packages/client-search/src/types/Log.ts
+++ b/packages/client-search/src/types/Log.ts
@@ -2,7 +2,7 @@ export type Log = {
   /**
    * Timestamp in ISO-8601 format.
    */
-  readonly timeStamp: string;
+  readonly timestamp: string;
 
   /**
    * Rest type of the method.
@@ -12,12 +12,12 @@ export type Log = {
   /**
    * Http response code.
    */
-  readonly answerCode: string;
+  readonly answer_code: string;
 
   /**
    * Request body. It’s truncated after 1000 characters.
    */
-  readonly queryBody: string;
+  readonly query_body: string;
 
   /**
    * Answer body. It’s truncated after 1000 characters.
@@ -42,22 +42,22 @@ export type Log = {
   /**
    * Request Headers (API Key is obfuscated).
    */
-  readonly queryHeaders: string;
+  readonly query_headers: string;
 
   /**
    * Number Of Api Calls
    */
-  readonly numberOfApiCalls: string;
+  readonly nb_api_calls: string;
 
   /**
    * Processing time for the query. This does not include network time.
    */
-  readonly processingTimeMS: string;
+  readonly processing_time_ms: string;
 
   /**
    * Number of hits returned for the query.
    */
-  readonly numberOfQueryHits: string;
+  readonly query_nb_hits?: string;
 
   /**
    * Exhaustive flags used during the query.
@@ -67,5 +67,5 @@ export type Log = {
   /**
    * Index name of the log
    */
-  readonly index: string;
+  readonly index?: string;
 };

--- a/packages/client-search/src/types/Log.ts
+++ b/packages/client-search/src/types/Log.ts
@@ -47,7 +47,7 @@ export type Log = {
   /**
    * Number Of Api Calls
    */
-  readonly nb_api_calls: string;
+  readonly nb_api_calls?: string;
 
   /**
    * Processing time for the query. This does not include network time.


### PR DESCRIPTION
Related issue: https://github.com/algolia/algoliasearch-client-javascript/issues/1137

This fixes the types of Log, as well as putting some field optionals