### PR TITLE
chore(release): small tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# algoliasearch contributing guide
+
+Hello and welcome to the contributing guide for algoliasearch. Thanks for considering participating in our project 🙇
+
+If this guide does not contain what you are looking for and thus prevents you from contributing, don't hesitate to leave a message on the [community forum](https://discourse.algolia.com/) or to [open an issue](https://github.com/algolia/algoliasearch-client-javascript/issues).
+
+## Reporting an issue
+
+Opening an issue is very effective way to contribute because many users might also be impacted. We'll make sure to fix it quickly if it's technically feasible and doesn't have important side effects for other users.
+
+Before reporting an issue, first check that there is not an already open issue for the same topic using the [issues page](https://github.com/algolia/algoliasearch-client-javascript/issues). Don't hesitate to thumb up an issue that corresponds to the problem you have.
+
+Another element that will help us go faster at solving the issue is to provide a reproducible test case.
+
+## The code contribution process
+
+algoliasearch is developed in TypeScript. For any code contribution, you need to:
+
+- Fork and clone the project
+- Create a new branch for what you want to solve (fix/_issue-number_, feat/_name-of-the-feature_)
+- Make your changes
+- Open a pull request
+
+Depending on what you're working on, you might consider different [base branches](#branch-organization).
+
+Then:
+
+- Peer review of the pull request (by at least one of the core contributors)
+- Automatic checks (tests, [commits](#commit-conventions), [linters](#linting))
+- When everything is green, your contribution is merged 🚀
+
+## Commit conventions
+
+This project follows the [conventional changelog](https://conventionalcommits.org/) approach. This means that all commit messages should be formatted using the following scheme:
+
+```
+type(scope): description
+```
+
+In most cases, we use the following types:
+
+- `fix`: for any resolution of an issue (identified or not)
+- `feat`: for any new feature
+- `refactor`: for any code change that neither adds a feature nor fixes an issue
+- `docs`: for any documentation change or addition
+- `chore`: for anything that is not related to the library itself (doc, tooling)
+
+Even though the scope is optional, we try to fill it in as it helps us better understand the impact of a change. We either use the name of the widget/connector/component impacted or we use impact topic (e.g. `docs`, `tooling`, `deps`, `ci`).
+
+Finally, if your work is based on an issue on GitHub, please add in the body of the commit message "fix #1234" if it solves the issue #1234 (read "[Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords)").
+
+Some examples of valid commit messages (used as first lines):
+
+> - fix(searchbox): increase magnifying glass size
+> - chore(deps): update dependency rollup-plugin-babel to v3.0.7
+> - fix(connectRefinementList): set default value for limit
+> - chore: reword contributions guides
+
+## Branch organization
+
+The project is based on the classic GitHub flow:
+
+- `master` for the current version being worked on – Pull requests for bugs and feature related to the current major version should be created against this branch
+- `vX` for each major version (`X` being a number) – Pull requests for critical bug fixes should be created against this branch
+
+Most of the time, your pull requests should target the `master` branch.
+
+_Note that no new features will be developed or backported for the `vX` branches._
+
+## Requirements
+
+To run this project, you will need:
+
+- Node.js ≥ 12 (current stable version) – [nvm](https://github.com/creationix/nvm#install-script) is recommended
+- [Yarn](https://yarnpkg.com)
+
+## Linting
+
+Linters are static checkers for code. They help us maintain a consistent code base. They are used for JavaScript and TypeScript files.
+
+If your editor support them, then you will see the errors directly there. You can also run them using your command line:
+
+```sh
+yarn lint
+```
+
+TypeScript files are validated using a combination of [Prettier](https://github.com/prettier/prettier) (strict syntax form) and [ESLint](https://github.com/eslint/eslint) rules (for common mistakes and patterns). We also use [API extractor](https://api-extractor.com) to validate the correct exported types.
+
+## Release
+
+### Main version
+
+To release a stable version, go on `master` (`git checkout master`) and use:
+
+```sh
+npm run release
+```
+
+If you're part of the Algolia team, you can read more details [here](https://github.com/algolia/doc-api-clients-squad/blob/master/release/javascript-v4.md)

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
   "apiReport": {
-    "enabled": false,
+    "enabled": false
   },
 
   "docModel": {

--- a/packages/client-analytics/src/types/GetABTestResponse.ts
+++ b/packages/client-analytics/src/types/GetABTestResponse.ts
@@ -32,13 +32,13 @@ export type GetABTestResponse = {
   abTestID: number;
 
   /**
-   * The ab test significance based on click data. Should be > 0.95 to be considered significant - no matter which variant is winning.
+   * The ab test significance based on click data. Should be higher than 0.95 to be considered significant - no matter which variant is winning.
    */
   clickSignificance: number;
 
   /**
    *
-   * The ab test significance based on conversion data. Should be > 0.95 to be considered significant - no matter which variant is winning.
+   * The ab test significance based on conversion data. Should be higher than 0.95 to be considered significant - no matter which variant is winning.
    */
   conversionSignificance: number;
 };

--- a/packages/client-analytics/src/types/Variant.ts
+++ b/packages/client-analytics/src/types/Variant.ts
@@ -16,10 +16,9 @@ export type Variant = {
    */
   readonly trafficPercentage: number;
 
+  // @todo Handle this search options type.
   /**
    * The search parameters.
-   *
-   * @todo Handle this search options type.
    */
   readonly customSearchParameters?: SearchOptions;
 };

--- a/packages/client-analytics/src/types/VariantResponse.ts
+++ b/packages/client-analytics/src/types/VariantResponse.ts
@@ -43,10 +43,9 @@ export type VariantResponse = Variant & {
    */
   userCount?: number;
 
+  // @todo Handle this search options type.
   /**
    * The search parameters.
-   *
-   * @todo Handle this search options type.
    */
   customSearchParameters?: SearchOptions;
 };

--- a/packages/client-search/src/types/HasPendingMappingsOptions.ts
+++ b/packages/client-search/src/types/HasPendingMappingsOptions.ts
@@ -2,14 +2,14 @@ export type HasPendingMappingsOptions = {
   /**
    * If the clusters pending mapping state should be on the response.
    *
-   * @default false
+   * @defaultValue false
    */
   readonly retrieveMappings?: boolean;
 
   /**
    * If the clusters pending mapping state should be on the response.
    *
-   * @default false
+   * @defaultValue false
    *
    * @internal
    */

--- a/packages/client-search/src/types/Rule.ts
+++ b/packages/client-search/src/types/Rule.ts
@@ -110,7 +110,7 @@ export type ConsequenceParams = {
 
 export type Condition = {
   /**
-   * Query patterns are expressed as a string with a specific syntax. A pattern is a sequence of tokens. 
+   * Query patterns are expressed as a string with a specific syntax. A pattern is a sequence of tokens.
    */
   readonly pattern?: string;
 

--- a/packages/client-search/src/types/Rule.ts
+++ b/packages/client-search/src/types/Rule.ts
@@ -53,7 +53,6 @@ export type AutomaticFacetFilter = {
 export type ConsequenceQuery = {
   /**
    * List of removes.
-   *
    */
   readonly remove?: readonly string[];
 
@@ -66,10 +65,14 @@ export type ConsequenceQuery = {
      */
     readonly type?: 'remove' | 'replace';
 
-    /** Text or patterns to remove from the query string. */
+    /**
+     * Text or patterns to remove from the query string.
+     */
     readonly delete?: string;
 
-    /** Text that should be inserted in place of the removed text inside the query string. */
+    /**
+     * Text that should be inserted in place of the removed text inside the query string.
+     */
     readonly insert?: string;
   }>;
 };
@@ -106,10 +109,14 @@ export type ConsequenceParams = {
 };
 
 export type Condition = {
-  /** Query patterns are expressed as a string with a specific syntax. A pattern is a sequence of tokens. */
+  /**
+   * Query patterns are expressed as a string with a specific syntax. A pattern is a sequence of tokens. 
+   */
   readonly pattern?: string;
 
-  /** { is | startsWith | endsWith | contains }: Whether the pattern must match the beginning or the end of the query string, or both, or none. */
+  /**
+   * is | startsWith | endsWith | contains: Whether the pattern must match the beginning or the end of the query string, or both, or none.
+   */
   readonly anchoring?: 'is' | 'startsWith' | 'endsWith' | 'contains';
 
   /**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ git fetch origin --tags
 
 currentVersion=`cat lerna.json | jq -r '.version'`
 
-printf "\n${RED}[ACTION]${NC} Checking CI status is an manual step! Check here: https://circleci.com/gh/algolia\n"
+printf "\n${RED}[ACTION]${NC} Checking CI status is an manual step! Check here: https://circleci.com/gh/algolia/algoliasearch-client-javascript\n"
 read -p "Is the latest commit a success? If yes, are you sure? (y/n): "
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
 


### PR DESCRIPTION
- add contributing guide (based on IS.js one)
- fix small error in api-extractor.json
- better link in CI comment in release script
- replace default with defaultValue: https://api-extractor.com/pages/tsdoc/tag_defaultvalue/
- put todo in separate comments so they aren't found by api-extractor
- avoid using > & {} in tsdoc comments, they can be confused with html apparently, and this looks nicer than the backslashes