### PR TITLE
feat(cache): allow export & import

### DIFF
--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -26,10 +26,13 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
       events: CacheEvents<TValue> = {
         miss: () => Promise.resolve(),
       }
-    ): Readonly<Promise<TValue>> {
+    ) {
       return Promise.resolve()
         .then(() => {
           const keyAsString = JSON.stringify(key);
+          // since TValue is needed for getNamespace to have the correct type
+          // we need to retype the whole get function.
+          // This could be fixed by making cache generic instead of its functions.
           const value = getNamespace<TValue>()[keyAsString];
 
           return Promise.all([value || defaultValue(), value !== undefined]);
@@ -40,7 +43,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
         .then(([value]) => value);
     },
 
-    set<TValue>(key: object | string, value: TValue): Readonly<Promise<TValue>> {
+    set(key, value) {
       return Promise.resolve().then(() => {
         const namespace = getNamespace();
 
@@ -53,7 +56,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
       });
     },
 
-    delete(key: object | string): Readonly<Promise<void>> {
+    delete(key) {
       return Promise.resolve().then(() => {
         const namespace = getNamespace();
 
@@ -64,10 +67,14 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
       });
     },
 
-    clear(): Readonly<Promise<void>> {
+    clear() {
       return Promise.resolve().then(() => {
         getStorage().removeItem(namespaceKey);
       });
+    },
+
+    entries() {
+      return Promise.resolve().then(() => getNamespace());
     },
   };
 }

--- a/packages/cache-common/src/types/Cache.ts
+++ b/packages/cache-common/src/types/Cache.ts
@@ -24,4 +24,9 @@ export type Cache = {
    * Clears the cache.
    */
   readonly clear: () => Readonly<Promise<void>>;
+
+  /**
+   * Retrieve the entries currently in cache.
+   */
+  readonly entries: () => Readonly<Promise<unknown>>;
 };

--- a/packages/cache-in-memory/src/createInMemoryCache.ts
+++ b/packages/cache-in-memory/src/createInMemoryCache.ts
@@ -1,51 +1,56 @@
-import { Cache, CacheEvents } from '@algolia/cache-common';
+import { Cache } from '@algolia/cache-common';
 
 import { InMemoryCacheOptions } from '.';
 
-export function createInMemoryCache(options: InMemoryCacheOptions = { serializable: true }): Cache {
+export function createInMemoryCache({
+  serializable = true,
+  initialCache = {},
+}: InMemoryCacheOptions = {}): Cache {
   // eslint-disable-next-line functional/no-let
-  let cache: Record<string, any> = {};
+  let cache: Record<string, any> = initialCache;
 
   return {
-    get<TValue>(
-      key: object | string,
-      defaultValue: () => Readonly<Promise<TValue>>,
-      events: CacheEvents<TValue> = {
+    get(
+      key,
+      defaultValue,
+      events = {
         miss: () => Promise.resolve(),
       }
-    ): Readonly<Promise<TValue>> {
+    ) {
       const keyAsString = JSON.stringify(key);
 
       if (keyAsString in cache) {
-        return Promise.resolve(
-          options.serializable ? JSON.parse(cache[keyAsString]) : cache[keyAsString]
-        );
+        return Promise.resolve(serializable ? JSON.parse(cache[keyAsString]) : cache[keyAsString]);
       }
 
       const promise = defaultValue();
       const miss = (events && events.miss) || (() => Promise.resolve());
 
-      return promise.then((value: TValue) => miss(value)).then(() => promise);
+      return promise.then(value => miss(value)).then(() => promise);
     },
 
-    set<TValue>(key: object | string, value: TValue): Readonly<Promise<TValue>> {
+    set(key, value) {
       // eslint-disable-next-line functional/immutable-data
-      cache[JSON.stringify(key)] = options.serializable ? JSON.stringify(value) : value;
+      cache[JSON.stringify(key)] = serializable ? JSON.stringify(value) : value;
 
       return Promise.resolve(value);
     },
 
-    delete(key: object | string): Readonly<Promise<void>> {
+    delete(key) {
       // eslint-disable-next-line functional/immutable-data
       delete cache[JSON.stringify(key)];
 
       return Promise.resolve();
     },
 
-    clear(): Readonly<Promise<void>> {
+    clear() {
       cache = {};
 
       return Promise.resolve();
+    },
+
+    entries() {
+      return Promise.resolve(cache);
     },
   };
 }

--- a/packages/cache-in-memory/src/types/InMemoryCacheOptions.ts
+++ b/packages/cache-in-memory/src/types/InMemoryCacheOptions.ts
@@ -3,4 +3,9 @@ export type InMemoryCacheOptions = {
    * If keys and values should be serialized using `JSON.stringify`.
    */
   readonly serializable?: boolean;
+
+  /**
+   * Cache to initialize the cache with, usually retrieved with cache.entries()
+   */
+  readonly initialCache?: Record<string, any>;
 };


### PR DESCRIPTION
In SSR, you usually want to do the same query on the server as on the client, however the query on the client is redundant, since the results are serialized.

The JS client needs elaborate workarounds right now (including aliasing the "search" method, like in [react-instantsearch](https://github.com/algolia/react-instantsearch/blob/c9666c0458aacf1bf0151f479f57de21032d68b7/packages/react-instantsearch-core/src/core/createInstantSearchManager.js#L341-L397)) to be able to initialize the memory cache with already done queries.

Another use case is for "prefilling" the cache for e.g. empty or really popular queries.