### PR TITLE
chore: fixes build error on the ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,10 @@ workflows:
       - test_unit:
           version: '13'
       - test_lint:
-          version: '12'
+          version: '12.18.0'
       - test_types:
-          version: '12'
+          version: '12.18.0'
       - test_build:
-          version: '12'
+          version: '12.18.0'
       - test_browser:
-          version: '12'
+          version: '12.18.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,10 +134,10 @@ workflows:
       - test_unit:
           version: '13'
       - test_lint:
-          version: '12.18.0'
+          version: '12'
       - test_types:
-          version: '12.18.0'
+          version: '12'
       - test_build:
-          version: '12.18.0'
+          version: '12.16.2'
       - test_browser:
-          version: '12.18.0'
+          version: '12.16.2'


### PR DESCRIPTION
**Note**: This needs to be squashed.

The CI on the build job, is currently using the latest version of node LTS: 12.18.0.

That version differs from the `nvm` lock: 12.16.2.

Due a change between 12.16.2 => 12.18.0, the CI is now displaying this error while building the bundle: `with error cannot find module @babel/compat-data/corejs3-shipped-proposals.`.

We had two solutions: 

- One is upgrade dev dependencies, but that makes the bundle size bigger. And we really don't have time to investigate this now. 🛑 
- The second one (the one used in this pull request) is lock the node version on the CI build job. ✅