### PR TITLE
chore(tests): tests against node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,8 @@ workflows:
           version: '12'
       - test_unit:
           version: '13'
+      - test_unit:
+          version: '14'
       - test_lint:
           version: '12'
       - test_types:


### PR DESCRIPTION
Node version 14 is available since the 21/04/2020: [medium.com/@nodejs/node-js-version-14-available-now-8170d384567e](https://medium.com/@nodejs/node-js-version-14-available-now-8170d384567e)

This pull request tests this library against that version.