### PR TITLE
fix(log-type-inner-queries): apply snake_case

### DIFF
--- a/packages/client-search/src/types/Log.ts
+++ b/packages/client-search/src/types/Log.ts
@@ -91,6 +91,6 @@ export type Log = {
     /**
      * The user token of the query.
      */
-    readonly user_token: string;
+    readonly user_token?: string;
   }>;
 };

--- a/packages/client-search/src/types/Log.ts
+++ b/packages/client-search/src/types/Log.ts
@@ -76,12 +76,12 @@ export type Log = {
     /**
      * Index name of the query.
      */
-    readonly indexName: string;
+    readonly index_name: string;
 
     /**
      * Query ID of the query.
      */
-    readonly queryID?: string;
+    readonly query_id?: string;
 
     /**
      * The offset of the query.
@@ -91,6 +91,6 @@ export type Log = {
     /**
      * The user token of the query.
      */
-    readonly userToken: string;
+    readonly user_token: string;
   }>;
 };


### PR DESCRIPTION
Hey @Ant-hem , can you confirm that the type is now correct? Including what is optional or not:

```ts
  inner_queries: Array<{
    index_name: string; // required
    query_id?: string; // optional
    offset?: number; // optional
    user_token?: string; // optional
  }>;
```