### PR TITLE
feat: multiple conditions on query rules

### DIFF
--- a/packages/client-search/src/__tests__/integration/rules.test.ts
+++ b/packages/client-search/src/__tests__/integration/rules.test.ts
@@ -43,7 +43,7 @@ test(testSuite.testName, async () => {
 
   const ruleToSave2: Rule = {
     objectID: 'query_edits',
-    condition: { anchoring: 'is', pattern: 'mobile phone', alternatives: true },
+    conditions: [{ anchoring: 'is', pattern: 'mobile phone', alternatives: true }],
     consequence: {
       params: {
         query: {

--- a/packages/client-search/src/types/Rule.ts
+++ b/packages/client-search/src/types/Rule.ts
@@ -12,6 +12,11 @@ export type Rule = {
   readonly condition?: Condition;
 
   /**
+   * Conditions of the rule, expressed using the following variables: pattern, anchoring, context.
+   */
+  readonly conditions?: readonly Condition[];
+
+  /**
    * Consequence of the rule. At least one of the following object must be used: params, promote, hide, userData.
    */
   readonly consequence?: Consequence;


### PR DESCRIPTION
This pull request adds the possibility of passing multiple conditions on query rules.

Closes https://github.com/algolia/algoliasearch-client-javascript/issues/1170.