### PR TITLE
feat(typescript): marks `condition` as deprecated on multiple conditions

### DIFF
--- a/packages/client-search/src/types/Rule.ts
+++ b/packages/client-search/src/types/Rule.ts
@@ -8,6 +8,8 @@ export type Rule = {
 
   /**
    * Condition of the rule, expressed using the following variables: pattern, anchoring, context.
+   *
+   * @deprecated This parameter is deprecated in favor of `conditions`.
    */
   readonly condition?: Condition;
 


### PR DESCRIPTION
This pull request marks the `condition` key as deprecated, as mentioned on the issue of this feature.

Fixes https://github.com/algolia/algoliasearch-client-javascript/issues/1170.