### PR TITLE
test(perso): work around limitations on setPersonalizationStrategy

### DIFF
--- a/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
+++ b/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
@@ -51,7 +51,7 @@ test(testSuite.testName, async () => {
     expect(response).toEqual(successResponse);
   } catch (error) {
     // eslint-disable-next-line jest/no-try-expect
-    expect(error).toEqual({ name: 'ApiError', ...errorResponse });
+    expect(error).toEqual(expect.objectContaining({ name: 'ApiError', ...errorResponse }));
   }
 
   await expect(client.getPersonalizationStrategy()).resolves.toEqual(personalizationStrategy);

--- a/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
+++ b/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
@@ -40,16 +40,17 @@ test(testSuite.testName, async () => {
     status: 200,
     message: 'Strategy was successfully updated',
   };
-  
+
   const errorResponse: SetPersonalizationStrategyResponse = {
     status: 429,
     message: 'Number of strategy saves exceeded for the day',
   };
-  
+
   try {
     const response = await client.setPersonalizationStrategy(personalizationStrategy);
     expect(response).toEqual(successResponse);
   } catch (error) {
+    // eslint-disable-next-line jest/no-try-expect
     expect(error).toEqual({ name: 'ApiError', ...errorResponse });
   }
 

--- a/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
+++ b/packages/client-recommendation/src/__tests__/features/personalization-strategy.test.ts
@@ -36,14 +36,22 @@ test(testSuite.testName, async () => {
     personalizationImpact: 0,
   };
 
-  const response: SetPersonalizationStrategyResponse = {
+  const successResponse: SetPersonalizationStrategyResponse = {
     status: 200,
     message: 'Strategy was successfully updated',
   };
-
-  await expect(client.setPersonalizationStrategy(personalizationStrategy)).resolves.toEqual(
-    response
-  );
+  
+  const errorResponse: SetPersonalizationStrategyResponse = {
+    status: 429,
+    message: 'Number of strategy saves exceeded for the day',
+  };
+  
+  try {
+    const response = await client.setPersonalizationStrategy(personalizationStrategy);
+    expect(response).toEqual(successResponse);
+  } catch (error) {
+    expect(error).toEqual({ name: 'ApiError', ...errorResponse });
+  }
 
   await expect(client.getPersonalizationStrategy()).resolves.toEqual(personalizationStrategy);
 });


### PR DESCRIPTION
fixes #1178

Basically the perso API has a limit of 15 calls per day, per application, which will make all tests fail. We prepare ourselves for this now, and also accept the 429 response to be correct