### PR TITLE
feat(createNodeHttpRequester): Add proxy support to another Agent on createNodeHttpRequester

### DIFF
--- a/packages/requester-node-http/package.json
+++ b/packages/requester-node-http/package.json
@@ -17,6 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "@algolia/requester-common": "4.3.1"
+    "@algolia/requester-common": "4.3.1",
+    "https-proxy-agent": "^5.0.0"
   }
 }

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -1,3 +1,4 @@
+/* eslint functional/prefer-readonly-type: 0 */
 /* eslint sonarjs/cognitive-complexity: 0 */ // -->
 
 import { Destroyable, Request, Requester, Response } from '@algolia/requester-common';
@@ -5,10 +6,20 @@ import * as http from 'http';
 import * as https from 'https';
 import * as URL from 'url';
 
-export function createNodeHttpRequester(agent: Object): Requester & Destroyable {
+export type NodeHttpRequesterOptions = {
+  agent?: https.Agent | http.Agent;
+  httpAgent?: http.Agent;
+  httpsAgent?: https.Agent;
+};
+
+export function createNodeHttpRequester({
+  agent: userGlobalAgent,
+  httpAgent: userHttpAgent,
+  httpsAgent: userHttpsAgent,
+}: NodeHttpRequesterOptions = {}): Requester & Destroyable {
   const agentOptions = { keepAlive: true };
-  const httpAgent = agent || new http.Agent(agentOptions);
-  const httpsAgent = agent || new https.Agent(agentOptions);
+  const httpAgent = userHttpAgent || userGlobalAgent || new http.Agent(agentOptions);
+  const httpsAgent = userHttpsAgent || userGlobalAgent || new https.Agent(agentOptions);
 
   return {
     send(request: Request): Readonly<Promise<Response>> {
@@ -27,7 +38,7 @@ export function createNodeHttpRequester(agent: Object): Requester & Destroyable 
         };
 
         const req = (url.protocol === 'https:' ? https : http).request(options, response => {
-          // eslint-disable-next-line functional/no-let, functional/prefer-readonly-type
+          // eslint-disable-next-line functional/no-let
           let contentBuffers: Buffer[] = [];
 
           response.on('data', chunk => {

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -1,14 +1,15 @@
 /* eslint sonarjs/cognitive-complexity: 0 */ // -->
 
 import { Destroyable, Request, Requester, Response } from '@algolia/requester-common';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import * as http from 'http';
 import * as https from 'https';
 import * as URL from 'url';
 
-export function createNodeHttpRequester(): Requester & Destroyable {
+export function createNodeHttpRequester(proxy: String): Requester & Destroyable {
   const agentOptions = { keepAlive: true };
-  const httpAgent = new http.Agent(agentOptions);
-  const httpsAgent = new https.Agent(agentOptions);
+  const httpAgent = proxy ? new HttpsProxyAgent(proxy) : new http.Agent(agentOptions);
+  const httpsAgent = proxy ? new HttpsProxyAgent(proxy) : new https.Agent(agentOptions);
 
   return {
     send(request: Request): Readonly<Promise<Response>> {


### PR DESCRIPTION
Hey guys, today i needed call Algolia behind my entherprise proxy server.

I did not found no way to do this with this lib so I added to the createNodeHttpRequester this feature.

To use it, you need to pass the proxy url to requester option.

https://www.algolia.com/doc/api-client/advanced/configure-the-client/javascript/?language=javascript#requester

like this:

const algoliasearch = algoliasearch(
  'YourApplicationID',
  'YourSearchOnlyAPIKey',
  {
    requester: createNodeHttpRequester('http://yourproxy:8080')
  },
);


