### PR TITLE
fix(getObject): null in return type for items

### DIFF
--- a/packages/client-search/src/types/GetObjectsResponse.ts
+++ b/packages/client-search/src/types/GetObjectsResponse.ts
@@ -4,5 +4,5 @@ export type GetObjectsResponse<TObject> = {
   /**
    * The list of results.
    */
-  results: Array<TObject & ObjectWithObjectID>;
+  results: Array<(TObject & ObjectWithObjectID) | null>;
 };


### PR DESCRIPTION
Using `getObjects` returns an array of records but also `null` when the object id doesn't match any record. Updating the type to reflect that.

See example of a response where the first object id matches a record and the second (object id "z") doesn't:
![image](https://user-images.githubusercontent.com/11643701/90509447-9f597380-e159-11ea-8b57-03eb97060f1f.png)
