### PR TITLE
fix(client-analytics): A/B Test VariantResponse typing

### DIFF
--- a/packages/client-analytics/src/types/VariantResponse.ts
+++ b/packages/client-analytics/src/types/VariantResponse.ts
@@ -6,7 +6,7 @@ export type VariantResponse = Variant & {
   /**
    * Average click position for the variant.
    */
-  averageClickPostion?: number;
+  averageClickPosition?: number;
 
   /**
    * Distinct click count for the variant.
@@ -32,6 +32,11 @@ export type VariantResponse = Variant & {
    * No result count.
    */
   noResultCount?: number;
+
+  /**
+   * Tracked search count.
+   */
+  trackedSearchCount?: number;
 
   /**
    * Search count.


### PR DESCRIPTION
- Fixed typo: `averageClickPostion` -> `averageClickPosition`
- Added missing attribute `trackedSearchCount`

<img width="767" alt="Screenshot 2020-08-22 at 11 07 46" src="https://user-images.githubusercontent.com/1584370/90953040-8eb24180-e468-11ea-8788-756d681c455e.png">
