### PR TITLE
fix(client-analytics): add missing updatedAt attribute

### DIFF
--- a/packages/client-analytics/src/types/GetABTestResponse.ts
+++ b/packages/client-analytics/src/types/GetABTestResponse.ts
@@ -27,6 +27,11 @@ export type GetABTestResponse = {
   createdAt: string;
 
   /**
+   * The ab test updated date.
+   */
+  updatedAt: string;
+
+  /**
    * The ab test unique identifier.
    */
   abTestID: number;


### PR DESCRIPTION
Add missing `updatedAt` attribute to `GetABTestResponse` type