### PR TITLE
feat(hosts): accept url as string

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,11 +97,11 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.53KB"
+      "maxSize": "7.56KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",
-      "maxSize": "4.29KB"
+      "maxSize": "4.35KB"
     }
   ]
 }

--- a/packages/transporter/src/__tests__/unit/hosts.test.ts
+++ b/packages/transporter/src/__tests__/unit/hosts.test.ts
@@ -69,4 +69,14 @@ describe('selection of hosts', (): void => {
       protocol: 'https',
     });
   });
+
+  it('allows a string to be passed', () => {
+    const host = createStatelessHost('foo.com');
+
+    expect(host).toEqual({
+      url: 'foo.com',
+      accept: CallEnum.Any,
+      protocol: 'https',
+    });
+  });
 });

--- a/packages/transporter/src/createStatelessHost.ts
+++ b/packages/transporter/src/createStatelessHost.ts
@@ -1,6 +1,14 @@
 import { CallEnum, HostOptions, StatelessHost } from '.';
 
 export function createStatelessHost(options: HostOptions): StatelessHost {
+  if (typeof options === 'string') {
+    return {
+      protocol: 'https',
+      url: options,
+      accept: CallEnum.Any,
+    };
+  }
+
   return {
     protocol: options.protocol || 'https',
     url: options.url,

--- a/packages/transporter/src/types/HostOptions.ts
+++ b/packages/transporter/src/types/HostOptions.ts
@@ -1,18 +1,20 @@
 import { CallType } from '.';
 
-export type HostOptions = {
-  /**
-   * The url of the server, without the protocol.
-   */
-  readonly url: string;
+export type HostOptions =
+  | string
+  | {
+      /**
+       * The url of the server, without the protocol.
+       */
+      readonly url: string;
 
-  /**
-   * The type of host. Defaults to `Any`.
-   */
-  readonly accept?: CallType;
+      /**
+       * The type of host. Defaults to `Any`.
+       */
+      readonly accept?: CallType;
 
-  /**
-   * The protocol. Defaults to `https`.
-   */
-  readonly protocol?: string;
-};
+      /**
+       * The protocol. Defaults to `https`.
+       */
+      readonly protocol?: string;
+    };


### PR DESCRIPTION
In v3 the API was `hosts: string[]`. It's easy to miss out on this in the migration guide, and it's also simpler to write just a string in the general case

fixes #1188