### PR TITLE
feat(types): introduce generic `Hit` type

### DIFF
--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -5,7 +5,7 @@ type HighlightMatch = {
   readonly fullyHighlighted?: boolean;
 };
 
-type HighlightResult<THit> = THit extends string | number
+export type HighlightResult<THit> = THit extends string | number
   ? HighlightMatch
   : {
       [KAttribute in keyof THit]: HighlightResult<THit[KAttribute]>;
@@ -16,7 +16,7 @@ type SnippetMatch = {
   readonly matchLevel: 'none' | 'partial' | 'full';
 };
 
-type SnippetResult<THit> = THit extends string | number
+export type SnippetResult<THit> = THit extends string | number
   ? SnippetMatch
   : {
       [KAttribute in keyof THit]: SnippetResult<THit[KAttribute]>;

--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -1,0 +1,47 @@
+type HighlightMatch = {
+  readonly value: string;
+  readonly matchLevel: 'none' | 'partial' | 'full';
+  readonly matchedWords: readonly string[];
+  readonly fullyHighlighted?: boolean;
+};
+
+type Highlight<THit> = THit extends string | number
+  ? HighlightMatch
+  : {
+      [KAttribute in keyof THit]: Highlight<THit[KAttribute]>;
+    };
+
+type SnippetMatch = {
+  readonly value: string;
+  readonly matchLevel: 'none' | 'partial' | 'full';
+};
+
+type Snippet<THit> = THit extends string | number
+  ? SnippetMatch
+  : {
+      [KAttribute in keyof THit]: Snippet<THit[KAttribute]>;
+    };
+
+export type Hit<THit> = THit & {
+  readonly objectID: string;
+  readonly _highlightResult?: Highlight<THit>;
+  readonly _snippetResult?: Snippet<THit>;
+  readonly _rankingInfo?: {
+    readonly promoted: boolean;
+    readonly nbTypos: number;
+    readonly firstMatchedWord: number;
+    readonly proximityDistance?: number;
+    readonly geoDistance: number;
+    readonly geoPrecision?: number;
+    readonly nbExactWords: number;
+    readonly words: number;
+    readonly filters: number;
+    readonly userScore: number;
+    readonly matchedGeoLocation?: {
+      readonly lat: number;
+      readonly lng: number;
+      readonly distance: number;
+    };
+  };
+  readonly _distinctSeqID?: number;
+};

--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -5,10 +5,10 @@ type HighlightMatch = {
   readonly fullyHighlighted?: boolean;
 };
 
-type Highlight<THit> = THit extends string | number
+type HighlightResult<THit> = THit extends string | number
   ? HighlightMatch
   : {
-      [KAttribute in keyof THit]: Highlight<THit[KAttribute]>;
+      [KAttribute in keyof THit]: HighlightResult<THit[KAttribute]>;
     };
 
 type SnippetMatch = {
@@ -16,16 +16,16 @@ type SnippetMatch = {
   readonly matchLevel: 'none' | 'partial' | 'full';
 };
 
-type Snippet<THit> = THit extends string | number
+type SnippetResult<THit> = THit extends string | number
   ? SnippetMatch
   : {
-      [KAttribute in keyof THit]: Snippet<THit[KAttribute]>;
+      [KAttribute in keyof THit]: SnippetResult<THit[KAttribute]>;
     };
 
 export type Hit<THit> = THit & {
   readonly objectID: string;
-  readonly _highlightResult?: Highlight<THit>;
-  readonly _snippetResult?: Snippet<THit>;
+  readonly _highlightResult?: HighlightResult<THit>;
+  readonly _snippetResult?: SnippetResult<THit>;
   readonly _rankingInfo?: {
     readonly promoted: boolean;
     readonly nbTypos: number;

--- a/packages/client-search/src/types/MultipleQueriesResponse.ts
+++ b/packages/client-search/src/types/MultipleQueriesResponse.ts
@@ -1,8 +1,8 @@
-import { ObjectWithObjectID, SearchResponse } from '.';
+import { Hit, SearchResponse } from '.';
 
 export type MultipleQueriesResponse<TObject> = {
   /**
    * The list of results.
    */
-  results: Array<SearchResponse<TObject & ObjectWithObjectID>>;
+  results: Array<SearchResponse<Hit<TObject>>>;
 };

--- a/packages/client-search/src/types/MultipleQueriesResponse.ts
+++ b/packages/client-search/src/types/MultipleQueriesResponse.ts
@@ -1,8 +1,8 @@
-import { Hit, SearchResponse } from '.';
+import { SearchResponse } from '.';
 
 export type MultipleQueriesResponse<TObject> = {
   /**
    * The list of results.
    */
-  results: Array<SearchResponse<Hit<TObject>>>;
+  results: Array<SearchResponse<TObject>>;
 };

--- a/packages/client-search/src/types/SearchResponse.ts
+++ b/packages/client-search/src/types/SearchResponse.ts
@@ -1,4 +1,4 @@
-import { ObjectWithObjectID } from '.';
+import { Hit } from '.';
 
 export type SearchResponse<TObject = {}> = {
   /**
@@ -6,7 +6,7 @@ export type SearchResponse<TObject = {}> = {
    *
    * Hits are ordered according to the ranking or sorting of the index being queried.
    */
-  hits: Array<TObject & ObjectWithObjectID>;
+  hits: Array<Hit<TObject>>;
 
   /**
    * Index of the current page (zero-based).

--- a/packages/client-search/src/types/index.ts
+++ b/packages/client-search/src/types/index.ts
@@ -36,6 +36,7 @@ export * from './GetObjectsResponse';
 export * from './GetTopUserIDsResponse';
 export * from './HasPendingMappingsOptions';
 export * from './HasPendingMappingsResponse';
+export * from './Hit';
 export * from './IndexOperationResponse';
 export * from './Indice';
 export * from './ListApiKeysResponse';


### PR DESCRIPTION
This introduces a new generic `Hit` type that infers values for records' highlighting and snippeting results.