### PR TITLE
fix: missing enablePersonalization in Settings

### DIFF
--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -155,6 +155,11 @@ export type Settings = {
    * Whether rules should be globally enabled.
    */
   readonly enableRules?: boolean;
+  
+   /**
+   * Whether personalization should be globally enabled.
+   */
+  readonly enablePersonalization?: boolean;
 
   /**
    * Controls if and how query words are interpreted as prefixes.


### PR DESCRIPTION
See here
https://www.algolia.com/doc/api-reference/api-parameters/enablePersonalization/

`enablePersonalization` is currently defined as a `Search` parameter but not a `Setting`