### PR TITLE
feat(client-search): add personalization field to RankingInfo

### DIFF
--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -22,26 +22,28 @@ export type SnippetResult<THit> = THit extends string | number
       [KAttribute in keyof THit]: SnippetResult<THit[KAttribute]>;
     };
 
+export type RankingInfo = {
+  readonly promoted: boolean;
+  readonly nbTypos: number;
+  readonly firstMatchedWord: number;
+  readonly proximityDistance?: number;
+  readonly geoDistance: number;
+  readonly geoPrecision?: number;
+  readonly nbExactWords: number;
+  readonly words: number;
+  readonly filters: number;
+  readonly userScore: number;
+  readonly matchedGeoLocation?: {
+    readonly lat: number;
+    readonly lng: number;
+    readonly distance: number;
+  };
+};
+
 export type Hit<THit> = THit & {
   readonly objectID: string;
   readonly _highlightResult?: HighlightResult<THit>;
   readonly _snippetResult?: SnippetResult<THit>;
-  readonly _rankingInfo?: {
-    readonly promoted: boolean;
-    readonly nbTypos: number;
-    readonly firstMatchedWord: number;
-    readonly proximityDistance?: number;
-    readonly geoDistance: number;
-    readonly geoPrecision?: number;
-    readonly nbExactWords: number;
-    readonly words: number;
-    readonly filters: number;
-    readonly userScore: number;
-    readonly matchedGeoLocation?: {
-      readonly lat: number;
-      readonly lng: number;
-      readonly distance: number;
-    };
-  };
+  readonly _rankingInfo?: RankingInfo;
   readonly _distinctSeqID?: number;
 };

--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -38,6 +38,11 @@ export type RankingInfo = {
     readonly lng: number;
     readonly distance: number;
   };
+  readonly personalization?: {
+    readonly filtersScore: number;
+    readonly rankingScore: number;
+    readonly score: number;
+  };
 };
 
 export type Hit<THit> = THit & {


### PR DESCRIPTION
- Extract and expose `RankingInfo` type
- Add missing personalization field for ranking info