### PR TITLE
fix(node): allow passing requesterOptions

### DIFF
--- a/packages/requester-node-http/src/__tests__/unit/node-http-requester.test.ts
+++ b/packages/requester-node-http/src/__tests__/unit/node-http-requester.test.ts
@@ -251,3 +251,31 @@ describe('error handling', (): void => {
     expect(response.isTimedOut).toBe(false);
   });
 });
+
+describe('requesterOptions', () => {
+  it('allows to pass requesterOptions', async () => {
+    const body = JSON.stringify({ foo: 'bar' });
+    const requesterTmp = createNodeHttpRequester({
+      requesterOptions: {
+        headers: {
+          'x-algolia-foo': 'bar',
+        },
+      },
+    });
+
+    nock('https://algolia-dns.net', {
+      reqheaders: {
+        ...headers,
+        'x-algolia-foo': 'bar',
+      },
+    })
+      .post('/foo')
+      .query({ 'x-algolia-header': 'foo' })
+      .reply(200, body);
+
+    const response = await requesterTmp.send(requestStub);
+
+    expect(response.status).toBe(200);
+    expect(response.content).toBe(body);
+  });
+});

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -10,14 +10,14 @@ export type NodeHttpRequesterOptions = {
   agent?: https.Agent | http.Agent;
   httpAgent?: http.Agent;
   httpsAgent?: https.Agent;
-  requestOptions?: https.RequestOptions;
+  requesterOptions?: https.RequestOptions;
 };
 
 export function createNodeHttpRequester({
   agent: userGlobalAgent,
   httpAgent: userHttpAgent,
   httpsAgent: userHttpsAgent,
-  requestOptions = {},
+  requesterOptions = {},
 }: NodeHttpRequesterOptions = {}): Requester & Destroyable {
   const agentOptions = { keepAlive: true };
   const httpAgent = userHttpAgent || userGlobalAgent || new http.Agent(agentOptions);
@@ -37,7 +37,7 @@ export function createNodeHttpRequester({
           method: request.method,
           headers: request.headers,
           ...(url.port !== undefined ? { port: url.port || '' } : {}),
-          ...requestOptions,
+          ...requesterOptions,
         };
 
         const req = (url.protocol === 'https:' ? https : http).request(options, response => {

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -10,14 +10,14 @@ export type NodeHttpRequesterOptions = {
   agent?: https.Agent | http.Agent;
   httpAgent?: http.Agent;
   httpsAgent?: https.Agent;
-  requestOptions?: https.RequestOptions
+  requestOptions?: https.RequestOptions;
 };
 
 export function createNodeHttpRequester({
   agent: userGlobalAgent,
   httpAgent: userHttpAgent,
   httpsAgent: userHttpsAgent,
-  requestOptions = {}
+  requestOptions = {},
 }: NodeHttpRequesterOptions = {}): Requester & Destroyable {
   const agentOptions = { keepAlive: true };
   const httpAgent = userHttpAgent || userGlobalAgent || new http.Agent(agentOptions);

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -10,12 +10,14 @@ export type NodeHttpRequesterOptions = {
   agent?: https.Agent | http.Agent;
   httpAgent?: http.Agent;
   httpsAgent?: https.Agent;
+  requestOptions?: https.RequestOptions
 };
 
 export function createNodeHttpRequester({
   agent: userGlobalAgent,
   httpAgent: userHttpAgent,
   httpsAgent: userHttpsAgent,
+  requestOptions = {}
 }: NodeHttpRequesterOptions = {}): Requester & Destroyable {
   const agentOptions = { keepAlive: true };
   const httpAgent = userHttpAgent || userGlobalAgent || new http.Agent(agentOptions);
@@ -35,6 +37,7 @@ export function createNodeHttpRequester({
           method: request.method,
           headers: request.headers,
           ...(url.port !== undefined ? { port: url.port || '' } : {}),
+          ...requestOptions,
         };
 
         const req = (url.protocol === 'https:' ? https : http).request(options, response => {

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -40,7 +40,7 @@ export function createNodeHttpRequester({
           path,
           method: request.method,
           headers: {
-            ...(requesterOptions?.headers ? requesterOptions.headers : {}),
+            ...(requesterOptions && requesterOptions.headers ? requesterOptions.headers : {}),
             ...request.headers,
           },
           ...(url.port !== undefined ? { port: url.port || '' } : {}),

--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -34,13 +34,16 @@ export function createNodeHttpRequester({
         const path = url.query === null ? url.pathname : `${url.pathname}?${url.query}`;
 
         const options: https.RequestOptions = {
+          ...requesterOptions,
           agent: url.protocol === 'https:' ? httpsAgent : httpAgent,
           hostname: url.hostname,
           path,
           method: request.method,
-          headers: request.headers,
+          headers: {
+            ...(requesterOptions?.headers ? requesterOptions.headers : {}),
+            ...request.headers,
+          },
           ...(url.port !== undefined ? { port: url.port || '' } : {}),
-          ...requesterOptions,
         };
 
         const req = (url.protocol === 'https:' ? https : http).request(options, response => {


### PR DESCRIPTION
On the crawler we are trying to control more our http connections 
and we would like to modify the behavior of the client to test a few things, especially the `family` options.

This option is related to ip resolution and a "fix" to reduse some network errors like: `ENOTFOUND` `EAI_AGAIN`
Those errors are the most common ones that triggers the infamous "Unreachable hosts"
ref: https://github.com/nodejs/node/issues/5436#issuecomment-189474356
(personal opinion would be to use `family: 4` by default, DM for more about this)

If you are not confident letting people modify the whole options, we'll be fine with just the `family` option.