### PR TITLE
fix(node): reuse http agent across client

### DIFF
--- a/packages/requester-node-http/src/createNodeHttpRequester.ts
+++ b/packages/requester-node-http/src/createNodeHttpRequester.ts
@@ -12,14 +12,17 @@ export type NodeHttpRequesterOptions = {
   httpsAgent?: https.Agent;
 };
 
+const agentOptions = { keepAlive: true };
+const defaultHttpAgent = new http.Agent(agentOptions);
+const defaultHttpsAgent = new https.Agent(agentOptions);
+
 export function createNodeHttpRequester({
   agent: userGlobalAgent,
   httpAgent: userHttpAgent,
   httpsAgent: userHttpsAgent,
 }: NodeHttpRequesterOptions = {}): Requester & Destroyable {
-  const agentOptions = { keepAlive: true };
-  const httpAgent = userHttpAgent || userGlobalAgent || new http.Agent(agentOptions);
-  const httpsAgent = userHttpsAgent || userGlobalAgent || new https.Agent(agentOptions);
+  const httpAgent = userHttpAgent || userGlobalAgent || defaultHttpAgent;
+  const httpsAgent = userHttpsAgent || userGlobalAgent || defaultHttpsAgent;
 
   return {
     send(request: Request): Readonly<Promise<Response>> {


### PR DESCRIPTION
Similar to #1215

When you create multiple clients, wether by mistake or needed if you index to multiple app, http agents are recreated by default. That means they do not share the TCP pool and will race for TCP connection, even if they are the same.
If they do not share same domains, at least it still reduce the cost of maintaining multiple TCP pool.

Reusing the Agent allow to:
- reuse TCP connections, 
- reduce the chance of exhausting TCP connections on the host,
- reduce the CPU cost,
- and also reduce chance of getting `ENOTFOUND` `EAI_AGAIN` (Those errors are the most common ones that triggers the infamous "Unreachable hosts")

