### PR TITLE
chore(release): configure shipjs to use lerna

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,30 +1,31 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable import/no-commonjs */
 
-const fs = require('fs');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const fs = require('fs').promises;
 const path = require('path');
 
 module.exports = {
   monorepo: {
     mainVersionFile: 'package.json',
-    packagesToBump: ['packages/*'],
+    // no packages should be versioned by shipjs, lerna should do it!
+    packagesToBump: [],
     packagesToPublish: ['packages/*'],
   },
   getTagName: ({ version }) => `${version}`,
   conventionalChangelogArgs:
     '--config conventional-changelog.config.js --infile CHANGELOG.md --same-file',
-  versionUpdated({ version, dir }) {
-    // Update version in `lerna.json` file.
-    const lernaConfigPath = path.resolve(dir, 'lerna.json');
-    const lernaConfig = JSON.parse(fs.readFileSync(lernaConfigPath).toString());
-    lernaConfig.version = version;
-    fs.writeFileSync(lernaConfigPath, JSON.stringify(lernaConfig, null, 2));
+  async versionUpdated({ version, dir }) {
+    // Update version with lerna
+    await exec(`lerna version ${version} --no-git-tag-version --no-push --exact --yes`);
 
     // Update version in `packages/client-common/src/version.ts` file since
     // `shipjs prepare` does not seem to support Typescript version files
     // bumping (yet?).
     const clientCommonTypescriptPath = 'packages/client-common/src/version.ts';
     const clientCommonTypescript = path.resolve(dir, clientCommonTypescriptPath);
-    fs.writeFileSync(clientCommonTypescript, `export const version = '${version}';\n`);
+
+    await fs.writeFile(clientCommonTypescript, `export const version = '${version}';\n`);
   },
 };


### PR DESCRIPTION
basically if you don't use lerna to update the versions, internal versions get out of sync and the dependencies never get updated (even if we would run lerna version).

This PR solves that by preventing shipjs updating the versions and doing it all with lerna in versionUpdated hook