### PR TITLE
feat(analytics-reco): allow creation of clients with their own credentials

### DIFF
--- a/packages/algoliasearch/src/__tests__/default.test.ts
+++ b/packages/algoliasearch/src/__tests__/default.test.ts
@@ -146,6 +146,34 @@ describe('default preset', () => {
     expect(recommendation.transporter.userAgent).toBe(client.transporter.userAgent);
   });
 
+  test('allows clients to override credentials', () => {
+    const clientWithOptions = algoliasearch('appId', 'apiKey');
+
+    expect(clientWithOptions.transporter.headers['x-algolia-api-key']).toBe('apiKey');
+
+    const analytics = clientWithOptions.initAnalytics({
+      apiKey: 'analytics',
+    });
+    const recommendation = clientWithOptions.initRecommendation({
+      apiKey: 'recommendation',
+    });
+
+    expect(analytics.transporter.headers['x-algolia-api-key']).toBe('analytics');
+    expect(recommendation.transporter.headers['x-algolia-api-key']).toBe('recommendation');
+  });
+
+  test('allows clients to keep default credentials', () => {
+    const clientWithOptions = algoliasearch('appId', 'apiKey');
+
+    expect(clientWithOptions.transporter.headers['x-algolia-api-key']).toBe('apiKey');
+
+    const analytics = clientWithOptions.initAnalytics();
+    const recommendation = clientWithOptions.initRecommendation();
+
+    expect(analytics.transporter.headers['x-algolia-api-key']).toBe('apiKey');
+    expect(recommendation.transporter.headers['x-algolia-api-key']).toBe('apiKey');
+  });
+
   it('can be destroyed', () => {
     if (!testing.isBrowser()) {
       expect(client).toHaveProperty('destroy');

--- a/packages/algoliasearch/src/types/AlgoliaSearchOptions.ts
+++ b/packages/algoliasearch/src/types/AlgoliaSearchOptions.ts
@@ -3,13 +3,22 @@ import { ClientTransporterOptions } from '@algolia/client-common';
 import { RecommendationClientOptions } from '@algolia/client-recommendation';
 import { SearchClientOptions } from '@algolia/client-search';
 
-export type WithoutCredentials<TClient> = Omit<TClient, 'appId' | 'apiKey'>;
+type Credentials = { readonly appId: string; readonly apiKey: string };
+export type WithoutCredentials<TClientOptions extends Credentials> = Omit<
+  TClientOptions,
+  keyof Credentials
+>;
+export type OptionalCredentials<TClientOptions extends Credentials> = Omit<
+  TClientOptions,
+  keyof Credentials
+> &
+  Pick<Partial<TClientOptions>, keyof Credentials>;
 
 export type AlgoliaSearchOptions = Partial<ClientTransporterOptions> &
   WithoutCredentials<SearchClientOptions>;
 
 export type InitAnalyticsOptions = Partial<ClientTransporterOptions> &
-  WithoutCredentials<AnalyticsClientOptions>;
+  OptionalCredentials<AnalyticsClientOptions>;
 
 export type InitRecommendationOptions = Partial<ClientTransporterOptions> &
-  WithoutCredentials<RecommendationClientOptions>;
+  OptionalCredentials<RecommendationClientOptions>;

--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -49,7 +49,7 @@ export class TestSuite {
     client.transporter.hosts = [client.transporter.hosts[2]];
 
     // Also, since we are targeting always the same host, the
-    // server may take a litle more than expected to answer.
+    // server may take a little more than expected to answer.
     // To avoid timeouts we increase the timeouts duration
     // @ts-ignore
     client.transporter.timeouts = {


### PR DESCRIPTION
see https://github.com/algolia/algoliasearch-client-specs-internal/issues/144

This actually didn't need to change any code, just the types, since they didn't allow appId & apiKey, while they actually are passed along already