### PR TITLE
fix(ts): correct search response for facets_stats

### DIFF
--- a/packages/client-search/src/types/SearchResponse.ts
+++ b/packages/client-search/src/types/SearchResponse.ts
@@ -67,7 +67,7 @@ export type SearchResponse<TObject = {}> = {
   /**
    * Statistics for numerical facets.
    */
-  facetsStats?: Record<
+  facets_stats?: Record<
     string,
     {
       /**


### PR DESCRIPTION
https://www.algolia.com/doc/api-reference/api-methods/search/#method-response-facets_stats

as far as I can tell this was always wrong in v4