### PR TITLE
fix(ts): don't require every attribute to be highlighted

### DIFF
--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -8,7 +8,7 @@ type HighlightMatch = {
 export type HighlightResult<THit> = THit extends string | number
   ? HighlightMatch
   : {
-      [KAttribute in keyof THit]: HighlightResult<THit[KAttribute]>;
+      [KAttribute in keyof THit]?: HighlightResult<THit[KAttribute]>;
     };
 
 type SnippetMatch = {


### PR DESCRIPTION
we didn't notice this earlier, since in InstantSearch.js we didn't yet update to the version of algoliasearch including the highlighting. The type in algoliasearch is better than the one in InstantSearch though, so we can find a way to switch in the future