### PR TITLE
fix(ts): correct type for listIndices response

### DIFF
--- a/packages/client-search/src/types/Indice.ts
+++ b/packages/client-search/src/types/Indice.ts
@@ -1,18 +1,18 @@
-export type Indice = {
+export type Index = {
   /**
    * Index name.
    */
   readonly name: string;
 
   /**
-   * Index creation date.
+   * Index creation date. (ISO-8601 format)
    */
-  readonly createdAt: number;
+  readonly createdAt: string;
 
   /**
-   * Date of last update.
+   * Date of last update. (ISO-8601 format)
    */
-  readonly updatedAt: number;
+  readonly updatedAt: string;
 
   /**
    * Number of records contained in the index
@@ -32,7 +32,7 @@ export type Indice = {
   /**
    * Last build time in seconds.
    */
-  readonly lastBuildTimes: number;
+  readonly lastBuildTimeS: number;
 
   /**
    * Number of pending indexing operations.
@@ -43,4 +43,21 @@ export type Indice = {
    * A boolean which says whether the index has pending tasks.
    */
   readonly pendingTask: boolean;
+
+  /**
+   * Only present if the index is a replica.
+   * Contains the name of the related primary index.
+   */
+  readonly primary?: string;
+
+  /**
+   * Only present if the index is a primary index with replicas.
+   * Contains the names of all linked replicas.
+   */
+  readonly replicas?: readonly string[];
 };
+
+/**
+ * @deprecated please use `Index` instead of `Indice`
+ */
+export type Indice = Index;

--- a/packages/client-search/src/types/ListIndicesResponse.ts
+++ b/packages/client-search/src/types/ListIndicesResponse.ts
@@ -1,4 +1,4 @@
-import { Indice } from '.';
+import { Index } from '.';
 
 export type ListIndicesResponse = {
   /**
@@ -9,5 +9,5 @@ export type ListIndicesResponse = {
   /**
    * List of index response
    */
-  items: Indice[];
+  items: Index[];
 };


### PR DESCRIPTION
1. the type for createdAt & updatedAt is actually a string timestamp, not a number
2. the type should be called Index, not Indice
2. add the types for replica-related properties

see https://www.algolia.com/doc/api-reference/api-methods/list-indices/ for the reference