### PR TITLE
Update multipleQueries.ts

### DIFF
--- a/packages/client-search/src/methods/client/multipleQueries.ts
+++ b/packages/client-search/src/methods/client/multipleQueries.ts
@@ -27,7 +27,7 @@ export const multipleQueries = (base: SearchClient) => {
         data: {
           requests,
         },
-        cacheable: true,
+        cacheable: (requestOptions && requestOptions.cacheable) || true,
       },
       requestOptions
     );


### PR DESCRIPTION
I would like to bypass the cache for the same request. (eg refreshing) I'm not sure if there's another way to do this? (passing `must-revalidate` cache-control header for example)

is `cacheable` for request cache only or for both request and response?