### PR TITLE
Spell success properly

### DIFF
--- a/packages/transporter/src/concerns/retryDecision.ts
+++ b/packages/transporter/src/concerns/retryDecision.ts
@@ -26,7 +26,7 @@ export const retryDecision = <TResponse>(
   }
 
   if (isSuccess(response)) {
-    return outcomes.onSucess(response);
+    return outcomes.onSuccess(response);
   }
 
   return outcomes.onFail(response);
@@ -34,6 +34,6 @@ export const retryDecision = <TResponse>(
 
 export type Outcomes<TResponse> = {
   readonly onFail: (response: Response) => Readonly<Promise<never>>;
-  readonly onSucess: (response: Response) => Readonly<Promise<TResponse>>;
+  readonly onSuccess: (response: Response) => Readonly<Promise<TResponse>>;
   readonly onRetry: (response: Response) => Readonly<Promise<TResponse>>;
 };

--- a/packages/transporter/src/concerns/retryableRequest.ts
+++ b/packages/transporter/src/concerns/retryableRequest.ts
@@ -94,7 +94,11 @@ export function retryableRequest<TResponse>(
     };
 
     const decisions: Outcomes<TResponse> = {
-      onSucess: response => deserializeSuccess(response),
+      /**
+       * @deprecated this property is deprecated in favor of `onSuccess`
+       */
+      onSucess: response => onSuccess(response),
+      onSuccess: response => deserializeSuccess(response),
       onRetry(response) {
         const stackFrame = pushToStackTrace(response);
 


### PR DESCRIPTION
Warning: I'm not a JS developer so I have no idea if there might be BC-breaks in this PR or not. I also don't know if this might actually fix any bug, hence why I picked `refactor` here.