### PR TITLE
fix(answers): rename params to searchParameters

### DIFF
--- a/packages/client-search/src/types/FindAnswersOptions.ts
+++ b/packages/client-search/src/types/FindAnswersOptions.ts
@@ -4,5 +4,5 @@ export type FindAnswersOptions = {
   readonly attributesForPrediction?: readonly string[];
   readonly nbHits?: number;
   readonly threshold?: number;
-  readonly params?: SearchOptions;
+  readonly searchParameters?: SearchOptions;
 };


### PR DESCRIPTION
# Summary

This PR renames `params` to `searchParameters` in `FindAnswersOptions`.

`params` is still supported but the new `searchParameters` is recommended for better clarification.

Should we leave `params` and mark it as deprecated? Or just delete it since it's a type and deleting it won't affect runtime?