### PR TITLE
fix(types): update FindAnswersOptions

### DIFF
--- a/packages/client-search/src/types/FindAnswersOptions.ts
+++ b/packages/client-search/src/types/FindAnswersOptions.ts
@@ -1,8 +1,47 @@
 import { SearchOptions } from './SearchOptions';
 
 export type FindAnswersOptions = {
+  /**
+   * Attributes to use for predictions.
+   * If using the default (["*"]), all attributes are used to find answers.
+   */
   readonly attributesForPrediction?: readonly string[];
+
+  /**
+   * Maximum number of answers to retrieve from the Answers Engine.
+   * Cannot be greater than 1000.
+   */
   readonly nbHits?: number;
+
+  /**
+   * Threshold for the answers’ confidence score:
+   * only answers with extracts that score above this threshold are returned.
+   */
   readonly threshold?: number;
-  readonly searchParameters?: SearchOptions;
+
+  /**
+   * Whether the attribute name in which the answer was found should be returned.
+   * This option is expensive in processing time.
+   */
+  readonly returnExtractAttribute?: boolean;
+
+  /**
+   * Algolia search parameters to use to fetch the hits.
+   * Can be any search parameter, except:
+   *   - attributesToSnippet
+   *   - hitsPerPage
+   *   - queryType
+   *   - naturalLanguages and associated parameters
+   *     (removeStopWords, ignorePlurals, and removeWordsIfNoResults)
+   */
+  readonly searchParameters?: Omit<
+    SearchOptions,
+    | 'attributesToSnippet'
+    | 'hitsPerPage'
+    | 'queryType'
+    | 'naturalLanguages'
+    | 'removeStopWords'
+    | 'ignorePlurals'
+    | 'andremoveWordsIfNoResults'
+  >;
 };


### PR DESCRIPTION
## Summary

This PR updates the types of `FindAnswersOptions`

- add `returnExtractAttribute`
- omit some properties from `searchParameters`
- bring the descriptions from the documentation

ref: https://www.algolia.com/doc/rest-api/answers/