### PR TITLE
feat(types): support `type` and `facet` in search methods

### DIFF
--- a/packages/client-search/src/types/MultipleQueriesQuery.ts
+++ b/packages/client-search/src/types/MultipleQueriesQuery.ts
@@ -1,6 +1,13 @@
 import { SearchOptions } from '.';
 
-export type MultipleQueriesQuery = {
+type SharedMultipleQueriesQuery = {
+  /**
+   * The type of query to perform.
+   *
+   * @defaultValue "default"
+   */
+  readonly type?: 'default' | 'facet';
+
   /**
    * The index name.
    */
@@ -16,3 +23,17 @@ export type MultipleQueriesQuery = {
    */
   readonly query?: string;
 };
+
+export type MultipleQueriesQuery = SharedMultipleQueriesQuery &
+  (
+    | {
+        readonly type?: 'default';
+      }
+    | {
+        readonly type: 'facet';
+        /**
+         * The facet name.
+         */
+        readonly facet: string;
+      }
+  );


### PR DESCRIPTION
## Description

The engine recently added support for facet value search from the `search` and `multipleQueries` method.

This PR updates the `MultipleQueriesQuery` to reflect this change.

## Usage

```ts
searchClient
  .search([
    {
      indexName: 'instant_search',
      query: 'a',
    },
    {
      type: 'facet',
      indexName: 'instant_search',
      facet: 'categories',
      query: 'a',
    },
  ])
  .then(({ results }) => {
    console.log(results);
  });
```

## Related

- [Query object documentation](https://www.algolia.com/doc/api-reference/api-methods/multiple-queries/#method-param-query-object)