### PR TITLE
fix(api-keys): fix typing issues

### DIFF
--- a/packages/client-search/src/types/GetApiKeyResponse.ts
+++ b/packages/client-search/src/types/GetApiKeyResponse.ts
@@ -2,14 +2,14 @@ import { ApiKeyACLType } from '.';
 
 export type GetApiKeyResponse = {
   /**
-   * A Unix timestamp used to define the expiration date of the API key.
+   * The api key value
    */
   value: string;
 
   /**
-   * Date of creation.
+   * Date of creation (Unix timestamp).
    */
-  createdAt: string;
+  createdAt: number;
 
   /**
    * List of permissions the key contains.

--- a/packages/client-search/src/types/UpdateApiKeyOptions.ts
+++ b/packages/client-search/src/types/UpdateApiKeyOptions.ts
@@ -1,4 +1,11 @@
+import { ApiKeyACLType } from '.';
+
 export type UpdateApiKeyOptions = {
+  /**
+   * List of permissions the key contains.
+   */
+  readonly acl?: readonly ApiKeyACLType[];
+
   /**
    * A Unix timestamp used to define the expiration date of the API key.
    */


### PR DESCRIPTION
- `createdAt` is a unix timestamp when using `listApiKeys` or `getApiKey`, not a `string`
- `UpdateApiKeyOptions` is missing the `acl` attribute (See [documentation](https://www.algolia.com/doc/api-reference/api-methods/update-api-key/#method-param-acl))