### PR TITLE
fix(Rule): automaticOptionalFacetFilters take the same input as automaticFacetFilters

### DIFF
--- a/packages/client-search/src/types/Rule.ts
+++ b/packages/client-search/src/types/Rule.ts
@@ -124,7 +124,7 @@ export type ConsequenceParams = {
    * Same syntax as automaticFacetFilters, but the engine treats the filters as optional.
    * Behaves like optionalFilters.
    */
-  readonly automaticOptionalFacetFilters?: readonly AutomaticFacetFilter[];
+  readonly automaticOptionalFacetFilters?: readonly AutomaticFacetFilter[] | readonly string[];
 
   /**
    * Content defining how the search interface should be rendered.


### PR DESCRIPTION
Unless the documentation is wrong, the type should be the same.
(that also means there is no test for this use case)