### PR TITLE
feat(recommend): support multiple queries

### DIFF
--- a/packages/recommend/src/__tests__/getFrequentlyBoughtTogether.test.ts
+++ b/packages/recommend/src/__tests__/getFrequentlyBoughtTogether.test.ts
@@ -14,10 +14,12 @@ describe('getFrequentlyBoughtTogether', () => {
     const client = createMockedClient();
 
     await client.getFrequentlyBoughtTogether(
-      {
-        indexName: 'products',
-        objectID: 'B018APC4LE',
-      },
+      [
+        {
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+        },
+      ],
       {}
     );
 
@@ -46,15 +48,17 @@ describe('getFrequentlyBoughtTogether', () => {
   test('ignores `fallbackParameters`', async () => {
     const client = createMockedClient();
 
-    await client.getFrequentlyBoughtTogether({
-      // @ts-ignore `fallbackParameters` are not supposed to be passed
-      // according to the types
-      fallbackParameters: {
-        facetFilters: [],
+    await client.getFrequentlyBoughtTogether([
+      {
+        // @ts-ignore `fallbackParameters` are not supposed to be passed
+        // according to the types
+        fallbackParameters: {
+          facetFilters: [],
+        },
+        indexName: 'products',
+        objectID: 'B018APC4LE',
       },
-      indexName: 'products',
-      objectID: 'B018APC4LE',
-    });
+    ]);
 
     expect(client.transporter.read).toHaveBeenCalledTimes(1);
     expect(client.transporter.read).toHaveBeenCalledWith(

--- a/packages/recommend/src/__tests__/getRecommendations.test.ts
+++ b/packages/recommend/src/__tests__/getRecommendations.test.ts
@@ -14,11 +14,13 @@ describe('getRecommendations', () => {
     const client = createMockedClient();
 
     await client.getRecommendations(
-      {
-        model: 'bought-together',
-        indexName: 'products',
-        objectID: 'B018APC4LE',
-      },
+      [
+        {
+          model: 'bought-together',
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+        },
+      ],
       {}
     );
 
@@ -47,11 +49,13 @@ describe('getRecommendations', () => {
     const client = createMockedClient();
 
     await client.getRecommendations(
-      {
-        model: 'related-products',
-        indexName: 'products',
-        objectID: 'B018APC4LE',
-      },
+      [
+        {
+          model: 'related-products',
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+        },
+      ],
       {}
     );
 
@@ -65,6 +69,52 @@ describe('getRecommendations', () => {
               indexName: 'products',
               model: 'related-products',
               objectID: 'B018APC4LE',
+              threshold: 0,
+            },
+          ],
+        },
+        method: 'POST',
+        path: '1/indexes/*/recommendations',
+      },
+      {}
+    );
+  });
+
+  test('builds multiple requests', async () => {
+    const client = createMockedClient();
+
+    await client.getRecommendations(
+      [
+        {
+          model: 'related-products',
+          indexName: 'products',
+          objectID: 'B018APC4LE-1',
+        },
+        {
+          model: 'related-products',
+          indexName: 'products',
+          objectID: 'B018APC4LE-2',
+        },
+      ],
+      {}
+    );
+
+    expect(client.transporter.read).toHaveBeenCalledTimes(1);
+    expect(client.transporter.read).toHaveBeenCalledWith(
+      {
+        cacheable: true,
+        data: {
+          requests: [
+            {
+              indexName: 'products',
+              model: 'related-products',
+              objectID: 'B018APC4LE-1',
+              threshold: 0,
+            },
+            {
+              indexName: 'products',
+              model: 'related-products',
+              objectID: 'B018APC4LE-2',
               threshold: 0,
             },
           ],

--- a/packages/recommend/src/__tests__/getRelatedProducts.test.ts
+++ b/packages/recommend/src/__tests__/getRelatedProducts.test.ts
@@ -14,10 +14,12 @@ describe('getRelatedProducts', () => {
     const client = createMockedClient();
 
     await client.getRelatedProducts(
-      {
-        indexName: 'products',
-        objectID: 'B018APC4LE',
-      },
+      [
+        {
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+        },
+      ],
       {}
     );
 

--- a/packages/recommend/src/methods/getFrequentlyBoughtTogether.ts
+++ b/packages/recommend/src/methods/getFrequentlyBoughtTogether.ts
@@ -1,8 +1,8 @@
 import { RecommendClient, WithRecommendMethods } from '../types';
-import { getRecommendations, GetRecommendationsOptions } from './getRecommendations';
+import { getRecommendations, GetRecommendationsQuery } from './getRecommendations';
 
-export type GetFrequentlyBoughtTogetherOptions = Omit<
-  GetRecommendationsOptions,
+export type GetFrequentlyBoughtTogetherQuery = Omit<
+  GetRecommendationsQuery,
   'model' | 'fallbackParameters'
 >;
 
@@ -11,13 +11,13 @@ type GetFrequentlyBoughtTogether = (
 ) => WithRecommendMethods<RecommendClient>['getFrequentlyBoughtTogether'];
 
 export const getFrequentlyBoughtTogether: GetFrequentlyBoughtTogether = base => {
-  return (options, requestOptions) => {
+  return (queries, requestOptions) => {
     return getRecommendations(base)(
-      {
-        ...options,
+      queries.map(query => ({
+        ...query,
         fallbackParameters: {},
         model: 'bought-together',
-      },
+      })),
       requestOptions
     );
   };

--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -7,7 +7,7 @@ import {
   WithRecommendMethods,
 } from '../types';
 
-export type GetRecommendationsOptions = {
+export type GetRecommendationsQuery = {
   readonly indexName: string;
   readonly model: RecommendModel;
   readonly objectID: string;
@@ -22,16 +22,14 @@ type GetRecommendations = (
 ) => WithRecommendMethods<RecommendClient>['getRecommendations'];
 
 export const getRecommendations: GetRecommendations = base => {
-  return (options, requestOptions) => {
-    const requests: readonly GetRecommendationsOptions[] = [
-      {
-        // The `threshold` param is required by the endpoint to make it easier
-        // to provide a default value later, so we default it in the client
-        // so that users don't have to provide a value.
-        threshold: 0,
-        ...options,
-      },
-    ];
+  return (queries, requestOptions) => {
+    const requests: readonly GetRecommendationsQuery[] = queries.map(query => ({
+      // The `threshold` param is required by the endpoint to make it easier
+      // to provide a default value later, so we default it in the client
+      // so that users don't have to provide a value.
+      threshold: 0,
+      ...query,
+    }));
 
     return base.transporter.read(
       {

--- a/packages/recommend/src/methods/getRelatedProducts.ts
+++ b/packages/recommend/src/methods/getRelatedProducts.ts
@@ -1,19 +1,19 @@
 import { RecommendClient, WithRecommendMethods } from '../types';
-import { getRecommendations, GetRecommendationsOptions } from './getRecommendations';
+import { getRecommendations, GetRecommendationsQuery } from './getRecommendations';
 
-export type GetRelatedProductsOptions = Omit<GetRecommendationsOptions, 'model'>;
+export type GetRelatedProductsQuery = Omit<GetRecommendationsQuery, 'model'>;
 
 type GetRelatedProducts = (
   base: RecommendClient
 ) => WithRecommendMethods<RecommendClient>['getRelatedProducts'];
 
 export const getRelatedProducts: GetRelatedProducts = base => {
-  return (options, requestOptions) => {
+  return (queries, requestOptions) => {
     return getRecommendations(base)(
-      {
-        ...options,
+      queries.map(query => ({
+        ...query,
         model: 'related-products',
-      },
+      })),
       requestOptions
     );
   };

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -2,9 +2,9 @@ import { MultipleQueriesResponse, SearchOptions } from '@algolia/client-search';
 import { RequestOptions } from '@algolia/transporter';
 
 import {
-  GetFrequentlyBoughtTogetherOptions,
-  GetRecommendationsOptions,
-  GetRelatedProductsOptions,
+  GetFrequentlyBoughtTogetherQuery,
+  GetRecommendationsQuery,
+  GetRelatedProductsQuery,
 } from '../methods';
 
 export type WithRecommendMethods<TType> = TType & {
@@ -12,7 +12,7 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns recommendations.
    */
   readonly getRecommendations: <TObject>(
-    options: GetRecommendationsOptions,
+    queries: readonly GetRecommendationsQuery[],
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
 
@@ -20,7 +20,7 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns [Related Products](https://algolia.com/doc/guides/algolia-ai/recommend/#related-products).
    */
   readonly getRelatedProducts: <TObject>(
-    options: GetRelatedProductsOptions,
+    queries: readonly GetRelatedProductsQuery[],
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
 
@@ -28,7 +28,7 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns [Frequently Bought Together](https://algolia.com/doc/guides/algolia-ai/recommend/#frequently-bought-together) products.
    */
   readonly getFrequentlyBoughtTogether: <TObject>(
-    options: GetFrequentlyBoughtTogetherOptions,
+    queries: readonly GetFrequentlyBoughtTogetherQuery[],
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
 };


### PR DESCRIPTION
## Description

Before releasing the new Recommend API client, we changed the API to support multi-query on the methods. The methods only accept arrays now.

## Usage

```ts
import algoliarecommend from '@algolia/recommend';

const recommendClient = algoliarecommend('appId', 'apiKey');

recommendClient
  .getRelatedProducts([
    {
      /* ... */
    },
  ])
  .then((response) => {
    console.log(response);
  });
```