### PR TITLE
chore(release): force public access on npm release

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -16,6 +16,9 @@ module.exports = {
   getTagName: ({ version }) => `${version}`,
   conventionalChangelogArgs:
     '--config conventional-changelog.config.js --infile CHANGELOG.md --same-file',
+  publishCommand({ tag }) {
+    return `npm publish --access public --tag ${tag}`;
+  },
   async versionUpdated({ version, dir }) {
     // Update version with lerna
     await exec(`lerna version ${version} --no-git-tag-version --no-push --exact --yes`);


### PR DESCRIPTION
This will avoid issues like #1286 where new packages are published as private.

We've got a similar configuration for Autocomplete: https://github.com/algolia/autocomplete/blob/e019b4dd7968f23ba500235e866e74f05fbed9de/ship.config.js#L20-L22