### PR TITLE
fix(answers): omit original hits in response

### DIFF
--- a/packages/client-search/src/types/FindAnswersResponse.ts
+++ b/packages/client-search/src/types/FindAnswersResponse.ts
@@ -1,7 +1,7 @@
 import { Hit } from './Hit';
 import { SearchResponse } from './SearchResponse';
 
-export type FindAnswersResponse<TObject = {}> = SearchResponse<TObject> & {
+export type FindAnswersResponse<TObject = {}> = Omit<SearchResponse<TObject>, 'hits'> & {
   /**
    * The hits returned by the search.
    *


### PR DESCRIPTION
Without this, the type is Hit[] & AnswersHit[] (paraphrased), which causes TypeScript to require extra casting to read _answer, which isn't expected.