### PR TITLE
fix(recommend): expose correct key on window in umd

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,6 +81,7 @@ packagesConfig.push({
   packagesConfig.push({
     output: build === 'browser' ? 'algoliasearch' : 'algoliasearch-lite',
     package: 'algoliasearch',
+    name: 'algoliasearch',
     input: `src/builds/${build}.ts`,
     formats: ['esm-browser'],
     ignore: ['crypto'],
@@ -89,6 +90,7 @@ packagesConfig.push({
   packagesConfig.push({
     output: build === 'browser' ? 'algoliasearch' : 'algoliasearch-lite',
     package: 'algoliasearch',
+    name: 'algoliasearch',
     input: `src/builds/${build}.ts`,
     formats: ['umd'],
     external: ['dom'],
@@ -103,12 +105,14 @@ packagesConfig.push(
   {
     output: 'recommend',
     package: 'recommend',
+    name: '@algolia/recommend',
     input: `src/builds/browser.ts`,
     formats: ['esm-browser', 'umd'],
   },
   {
     output: 'recommend',
     package: 'recommend',
+    name: '@algolia/recommend',
     input: `src/builds/node.ts`,
     formats: ['cjs'],
   }
@@ -159,7 +163,7 @@ packagesConfig
       const isEsmBrowserBuild = /\.esm.browser.js$/.test(output.file);
 
       if (isUmdBuild) {
-        output.name = 'algoliasearch';
+        output.name = packageConfig.name;
         output.banner = createLicence(output.file);
       }
 


### PR DESCRIPTION
**Summary**

The umd output name was defaulted to `algoliasearch`, since it was the only one providing an umd file. As we now have the `@algolia/recommend` package that also exposes an umd file, we need to be able to override the output name.

See [this sandbox](https://codesandbox.io/s/xenodochial-wu-tp1kl) where `@algolia/recommend` is available on the `algoliasearch` name when importing the umd file.