### PR TITLE
fix(recommend): prevent `undefined` threshold

### DIFF
--- a/packages/recommend/src/__tests__/getRecommendations.test.ts
+++ b/packages/recommend/src/__tests__/getRecommendations.test.ts
@@ -126,7 +126,7 @@ describe('getRecommendations', () => {
     );
   });
 
-  test('override `undefined` threshold with default value', async () => {
+  test('overrides `undefined` threshold with default value', async () => {
     const client = createMockedClient();
 
     await client.getRecommendations(
@@ -152,6 +152,42 @@ describe('getRecommendations', () => {
               model: 'bought-together',
               objectID: 'B018APC4LE',
               threshold: 0,
+            },
+          ],
+        },
+        method: 'POST',
+        path: '1/indexes/*/recommendations',
+      },
+      {}
+    );
+  });
+
+  test('overrides default threshold value', async () => {
+    const client = createMockedClient();
+
+    await client.getRecommendations(
+      [
+        {
+          model: 'bought-together',
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+          threshold: 42,
+        },
+      ],
+      {}
+    );
+
+    expect(client.transporter.read).toHaveBeenCalledTimes(1);
+    expect(client.transporter.read).toHaveBeenCalledWith(
+      {
+        cacheable: true,
+        data: {
+          requests: [
+            {
+              indexName: 'products',
+              model: 'bought-together',
+              objectID: 'B018APC4LE',
+              threshold: 42,
             },
           ],
         },

--- a/packages/recommend/src/__tests__/getRecommendations.test.ts
+++ b/packages/recommend/src/__tests__/getRecommendations.test.ts
@@ -125,4 +125,40 @@ describe('getRecommendations', () => {
       {}
     );
   });
+
+  test('override `undefined` threshold with default value', async () => {
+    const client = createMockedClient();
+
+    await client.getRecommendations(
+      [
+        {
+          model: 'bought-together',
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+          threshold: undefined,
+        },
+      ],
+      {}
+    );
+
+    expect(client.transporter.read).toHaveBeenCalledTimes(1);
+    expect(client.transporter.read).toHaveBeenCalledWith(
+      {
+        cacheable: true,
+        data: {
+          requests: [
+            {
+              indexName: 'products',
+              model: 'bought-together',
+              objectID: 'B018APC4LE',
+              threshold: 0,
+            },
+          ],
+        },
+        method: 'POST',
+        path: '1/indexes/*/recommendations',
+      },
+      {}
+    );
+  });
 });

--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -9,11 +9,11 @@ type GetRecommendations = (
 export const getRecommendations: GetRecommendations = base => {
   return (queries: readonly RecommendationsQuery[], requestOptions) => {
     const requests: readonly RecommendationsQuery[] = queries.map(query => ({
+      ...query,
       // The `threshold` param is required by the endpoint to make it easier
       // to provide a default value later, so we default it in the client
       // so that users don't have to provide a value.
-      threshold: 0,
-      ...query,
+      threshold: query.threshold || 0,
     }));
 
     return base.transporter.read(


### PR DESCRIPTION
**Summary**

Sending `threshold: undefined` to the API client causes the default value (`0`) to be overridden.

[sandbox reproduction](https://codesandbox.io/s/frosty-star-73kq7?file=/src/index.js)

**Result**

The default value isn't overridden when sending `threshold: undefined`