### PR TITLE
chore: dockerize development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+**/.DS_Store

--- a/DOCKER_README.MD
+++ b/DOCKER_README.MD
@@ -1,0 +1,51 @@
+In this page you will find our recommended way of installing Docker on your machine. 
+This guide is made for OSX users.
+
+## Install docker
+
+Install [Docker Desktop](https://docs.docker.com/get-docker/).
+
+## Build the image
+
+```bash
+docker build -t algolia-js .
+```
+
+## Run the image
+
+You need to provide few environment variables at runtime to be able to run the [Common Test Suite](https://github.com/algolia/algoliasearch-client-specs/tree/master/common-test-suite).
+You can set them up directly in the command:
+
+```bash
+docker run -it --rm --env ALGOLIA_APP_ID=XXXXXX [...] -v $PWD:/app -v /app/node_modules -w /app algolia-js bash
+```
+
+However, we advise you to export them in your `.bashrc` or `.zshrc`. That way, you can use [Docker's shorten syntax](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file) to set your variables.
+
+```bash
+### This is needed only to run the full test suite
+docker run -it --rm --env ALGOLIA_APPLICATION_ID_1 \
+                    --env ALGOLIA_ADMIN_KEY_1 \
+                    --env ALGOLIA_SEARCH_KEY_1 \
+                    --env ALGOLIA_APPLICATION_ID_2 \
+                    --env ALGOLIA_ADMIN_KEY_2
+                    --env ALGOLIA_APPLICATION_ID_MCM \
+                    --env ALGOLIA_ADMIN_KEY_MCM \
+-v $PWD:/app -v /app/node_modules -w /app algolia-js bash
+```
+
+Once your container is running, any changes you make in your IDE are directly reflected in the container, except for the `node_modules` folder.  
+If you want to add or remove packages, you will have to rebuild the image, this is because the `node_modules` folder is installed in a different folder to improve performance.
+
+To launch the tests, you can use one of the following commands
+```shell script
+# run only the unit tests
+yarn test:unit
+
+# run a single test
+yarn test:unit nameOfYourTest
+```
+
+You can find more commands in the `package.json` file.
+
+Feel free to contact us if you have any questions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile
+FROM node:10-alpine
+
+# Install the dependencies in the parent folder so they don't get overriden by the bind mount
+WORKDIR /
+
+# Needed to compile some npm packages
+RUN apk add --no-cache bash python3 make g++
+
+COPY package.json yarn.lock ./
+
+RUN yarn install
+
+ENV NODE_PATH=/node_modules
+ENV PATH=/node_modules/.bin:$PATH
+
+WORKDIR /app
+COPY . ./


### PR DESCRIPTION
Ticket: [DI-14](https://algolia.atlassian.net/browse/DI-14)

In the sake of harmonisation and to ease development, this PR adds a docker file in which you can run the test or lint the code, while using your normal IDE.

They are a few caveats, the first one is that because we mount the project to the `/app` folder, the `node_modules` are shared and slow down the execution by a lot. To avoid that, the `node_modules` are installed in the parent folder (the root) and an empty volumes is mounted to avoid copying the pacakges from the host.  
This works fine but prevent the modification of the packages, and the image must be rebuilt when some are added.

I used [Docker Desktop](https://docs.docker.com/get-docker/) in the readme to install docker because docker machine is deprecated and the code is [archived](https://docs.docker.com/machine/).

To test the Dockerfile, follow the `DOCKER_README.MD` instructions and then run `yarn test:unit` for example.