### PR TITLE
fix(ci): update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,6 @@ version: 2.1
 jobs:
   test_build:
     description: Testing build & Test Size & Declarations File
-    parameters:
-      version:
-        type: string
     <<: *defaults
     steps:
       - checkout


### PR DESCRIPTION
**Summary**

Fixes Circle CI docker image issue

See https://circleci.com/developer/images/image/cimg/node for more informations

TLDR: `This image is designed to supercede the legacy CircleCI Node.js image, circleci/node.`

- Follow up of https://github.com/algolia/autocomplete/pull/752
- Fixes https://github.com/algolia/algoliasearch-client-javascript/pull/1308#issuecomment-935645182