### PR TITLE
fix(insideBoundingBox): allow type to be a string too

### DIFF
--- a/packages/client-search/src/types/DeleteByFiltersOptions.ts
+++ b/packages/client-search/src/types/DeleteByFiltersOptions.ts
@@ -34,7 +34,7 @@ export type DeleteByFiltersOptions = {
   /**
    * Search inside a rectangular area (in geo coordinates).
    */
-  readonly insideBoundingBox?: ReadonlyArray<readonly number[]>;
+  readonly insideBoundingBox?: ReadonlyArray<readonly number[]> | string;
 
   /**
    * Search inside a polygon (in geo coordinates).

--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -292,7 +292,7 @@ export type SearchOptions = {
   /**
    * Search inside a rectangular area (in geo coordinates).
    */
-  readonly insideBoundingBox?: ReadonlyArray<readonly number[]>;
+  readonly insideBoundingBox?: ReadonlyArray<readonly number[]> | string;
 
   /**
    * Search inside a polygon (in geo coordinates).


### PR DESCRIPTION
This PR adds the possibility for the `insideBoundingBox` type to be a string as well. The reason behind this improvement comes from the usage of `insideBoundingBox` in instantsearch.js where it is used as a string. 

More details in [this issue in instantsearch.js](https://github.com/algolia/instantsearch.js/issues/4916). 

I suppose this PR adds breaking changes as functions using `insideBoundingBox` with the sole expectation of it to be `ReadonlyArray<readonly number[]>` will have to be updated to check if it is one of both.

Here is an example of how it would be breaking:
```ts
type InsideBoundingBox = ReadonlyArray<readonly number[]> | string

function myFunction(insideBoundingBox: InsideBoundingBox) {
   insideBoundingBox.map(...) // TypeScript error as Type can now be string.
} 
```


( I searched to point this PR to v5 since it introduces breaking changes but could not find the related branch 😕)

