### PR TITLE
chore: disable renovate until the test suite is less flaky

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": [
     "config:js-lib",
     "algolia"
-  ]
+  ],
+  "enable": false
 }


### PR DESCRIPTION
Disable renovate until the CTS is in place, or some other way to make the test less flaky and able to run in parallel.