### PR TITLE
feat(node): dedupe in-flight network requests by default

### DIFF
--- a/packages/algoliasearch/src/builds/node.ts
+++ b/packages/algoliasearch/src/builds/node.ts
@@ -213,7 +213,7 @@ export default function algoliasearch(
     requester: createNodeHttpRequester(),
     logger: createNullLogger(),
     responsesCache: createNullCache(),
-    requestsCache: createNullCache(),
+    requestsCache: createInMemoryCache({ serializable: false }),
     hostsCache: createInMemoryCache(),
     userAgent: createUserAgent(version).add({
       segment: 'Node.js',


### PR DESCRIPTION
I'm wondering if we shouldn't even enable the responses cache as well, but at least the requestsCache is an obvious choice

Could be considered a breaking change