### PR TITLE
feat(types): add reranking engine settings to types

### DIFF
--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -359,4 +359,12 @@ export type SearchOptions = {
    * This parameter is only used to turn off Dynamic Re-Ranking (with false) at search time.
    */
   readonly enableReRanking?: boolean;
+
+  /**
+   * When Dynamic Re-Ranking is enabled, only records that match these filters will be impacted by Dynamic Re-Ranking.
+   */
+  readonly reRankingApplyFilter?:
+    | string
+    | readonly string[]
+    | ReadonlyArray<readonly string[] | string>;
 };

--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -348,8 +348,8 @@ export type Settings = {
    * Whether this index should use Dynamic Re-Ranking.
    * @link https://www.algolia.com/doc/guides/algolia-ai/re-ranking/
    *
-   * Note: In order for this parameter to work, the index needs to be opted in to the Dynamic Re-Ranking feature, if your plan allows it.
-   * This can be done in the dashboard.
+   * Note: You need to turn on Dynamic Re-Ranking on your index for it to have an effect on
+   * your search results. You can do this through the Re-Ranking page on the dashboard.
    */
   readonly enableReRanking?: boolean;
 

--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -343,4 +343,21 @@ export type Settings = {
       };
     };
   };
+
+  /**
+   * Whether this index should use Dynamic Re-Ranking.
+   * @link https://www.algolia.com/doc/guides/algolia-ai/re-ranking/
+   *
+   * Note: In order for this parameter to work, the index needs to be opted in to the Dynamic Re-Ranking feature, if your plan allows it.
+   * This can be done in the dashboard.
+   */
+  readonly enableReRanking?: boolean;
+
+  /**
+   * When Dynamic Re-Ranking is enabled, only records that match these filters will be impacted by Dynamic Re-Ranking.
+   */
+  readonly reRankingApplyFilter?:
+    | string
+    | readonly string[]
+    | ReadonlyArray<readonly string[] | string>;
 };


### PR DESCRIPTION
# feat(types): add reranking engine settings to types

## What
Updating the `Settings` and `SearchOptions` types to add two reranking properties:
- enableReRanking (already existed in `SearchOptions`)
-  reRankingApplyFilter

## Why
These settings already exist on the engine for some time. They are already used in the dashboard but without these type we are building up quite a few "@ts-ignore". 