### PR TITLE
# fix(types): updating reRankingApplyFilter type and adding new property to RankingInfo

### DIFF
--- a/packages/client-search/src/types/Hit.ts
+++ b/packages/client-search/src/types/Hit.ts
@@ -43,6 +43,7 @@ export type RankingInfo = {
     readonly rankingScore: number;
     readonly score: number;
   };
+  readonly promotedByReRanking?: boolean;
 };
 
 export type Hit<THit> = THit & {

--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -366,5 +366,6 @@ export type SearchOptions = {
   readonly reRankingApplyFilter?:
     | string
     | readonly string[]
-    | ReadonlyArray<readonly string[] | string>;
+    | ReadonlyArray<readonly string[] | string>
+    | null;
 };

--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -359,5 +359,6 @@ export type Settings = {
   readonly reRankingApplyFilter?:
     | string
     | readonly string[]
-    | ReadonlyArray<readonly string[] | string>;
+    | ReadonlyArray<readonly string[] | string>
+    | null;
 };


### PR DESCRIPTION
# fix(types): updating reRankingApplyFilter type and adding new property to RankingInfo

This is a follow up to #1378 

## What
1. Adding `null` to the list of possible types for the `reRankingApplyFilter` search/setting option
1. Adding property `promotedByReRanking` to the `RankingInfo` type.

## Why
1. This is how we reset the filter in the dashboard, it was an oversight in the first PR.
2. Has been sent back by the engine for some time but was never added to the client's types.