### PR TITLE
fix(types): allow mixed arrays in numeric and tag filters

### DIFF
--- a/packages/client-search/src/types/DeleteByFiltersOptions.ts
+++ b/packages/client-search/src/types/DeleteByFiltersOptions.ts
@@ -12,14 +12,14 @@ export type DeleteByFiltersOptions = {
   /**
    * Filter on numeric attributes.
    */
-  readonly numericFilters?: string | readonly string[] | ReadonlyArray<readonly string[]>;
+  readonly numericFilters?: string | readonly string[] | ReadonlyArray<readonly string[] | string>;
 
   /**
    * Filter hits by tags. tagFilters is a different way of filtering, which relies on the _tags
    * attribute. It uses a simpler syntax than filters. You can use it when you want to do
    * simple filtering based on tags.
    */
-  readonly tagFilters?: string | readonly string[] | ReadonlyArray<readonly string[]>;
+  readonly tagFilters?: string | readonly string[] | ReadonlyArray<readonly string[] | string>;
 
   /**
    * Search for entries around a central geolocation, enabling a geo search within a circular area.

--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -24,14 +24,14 @@ export type SearchOptions = {
   /**
    * Filter on numeric attributes.
    */
-  readonly numericFilters?: string | readonly string[] | ReadonlyArray<readonly string[]>;
+  readonly numericFilters?: string | readonly string[] | ReadonlyArray<readonly string[] | string>;
 
   /**
    * Filter hits by tags. tagFilters is a different way of filtering, which relies on the _tags
    * attribute. It uses a simpler syntax than filters. You can use it when you want to do
    * simple filtering based on tags.
    */
-  readonly tagFilters?: string | readonly string[] | ReadonlyArray<readonly string[]>;
+  readonly tagFilters?: string | readonly string[] | ReadonlyArray<readonly string[] | string>;
 
   /**
    * Determines how to calculate the total score for filtering.


### PR DESCRIPTION
Correct me if I'm wrong, but I believe the fix for `facetFilters` in #1384 should apply to `numericFilters` and `tagFilters` as well.
