### PR TITLE
fix(recommend): declare type before usage

### DIFF
--- a/packages/recommend/src/types/RecommendModel.ts
+++ b/packages/recommend/src/types/RecommendModel.ts
@@ -1,2 +1,2 @@
-export type RecommendModel = 'related-products' | 'bought-together' | TrendingModel;
 export type TrendingModel = 'trending-items' | 'trending-facets';
+export type RecommendModel = 'related-products' | 'bought-together' | TrendingModel;


### PR DESCRIPTION
## Summary

Auto-merge was enabled, which skipped https://github.com/algolia/algoliasearch-client-javascript/pull/1396#discussion_r825795334

This PR move the `TrendingModel` type declaration before its usage in `RecommendModel`