### PR TITLE
feat(search): add type for queryLanguages

### DIFF
--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -368,4 +368,9 @@ export type SearchOptions = {
     | readonly string[]
     | ReadonlyArray<readonly string[] | string>
     | null;
+
+  /**
+   * Sets the languages to be used by language-specific settings and functionalities such as ignorePlurals, removeStopWords, and CJK word-detection.
+   */
+  readonly queryLanguages?: readonly string[];
 };


### PR DESCRIPTION
According to https://www.algolia.com/doc/api-reference/api-parameters/queryLanguages/?client=javascript, it can be sent as a search parameter too.

fixes #1405