### PR TITLE
fix(types): Updating searchoptions with explain attribute

### DIFF
--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -373,4 +373,11 @@ export type SearchOptions = {
    * Sets the languages to be used by language-specific settings and functionalities such as ignorePlurals, removeStopWords, and CJK word-detection.
    */
   readonly queryLanguages?: readonly string[];
+
+  /**
+   * Enriches the API’s response with meta-information as to how the query was processed. This attirbute powers the 'Query Alternatives' explanation.
+   * There is currently no official documentation on the API for this attribute.
+   * @link RFC: https://docs.google.com/document/d/1Z58mZks5EiF1z0tbswLpKMSw-rRngRpESdBqGoAAzDo
+   */
+  readonly explain?: readonly string[];
 };

--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -375,9 +375,7 @@ export type SearchOptions = {
   readonly queryLanguages?: readonly string[];
 
   /**
-   * Enriches the API’s response with meta-information as to how the query was processed. This attirbute powers the 'Query Alternatives' explanation.
-   * There is currently no official documentation on the API for this attribute.
-   * @link RFC: https://docs.google.com/document/d/1Z58mZks5EiF1z0tbswLpKMSw-rRngRpESdBqGoAAzDo
+   * Enriches the API’s response with meta-information as to how the query was processed.
    */
   readonly explain?: readonly string[];
 };


### PR DESCRIPTION
### Motivation

- Update the `SearchOptions` to include `explain` as a typed parameter for better use within the Algolia dashboard

### How

- Adds the `explain` attribute as a `string[]` to the V4 `SearchOptions`.

### Testing

- Test cases shouldn't change. The attribute is already included in a search test [here](https://github.com/algolia/algoliasearch-client-javascript/blob/master/packages/client-search/src/__tests__/integration/search.test.ts#L159)