### PR TITLE
fix(types): add `abTestID` to `SearchResponse`

### DIFF
--- a/packages/client-search/src/types/SearchResponse.ts
+++ b/packages/client-search/src/types/SearchResponse.ts
@@ -156,6 +156,11 @@ export type SearchResponse<TObject = {}> = {
   indexUsed?: string;
 
   /**
+   * If a search encounters an index that is being A/B tested, abTestID reports the ongoing A/B test ID.
+   */
+  abTestID?: number;
+
+  /**
    * In case of AB test, reports the variant ID used. The variant ID is the position in the array of variants (starting at 1).
    */
   abTestVariantID?: number;


### PR DESCRIPTION
## Summary

Ticket: https://algolia.atlassian.net/browse/CR-1581

Fixes https://github.com/algolia/algoliasearch-client-javascript/issues/1418

Add `abTestID` field to the `SearchResponse` type.