### PR TITLE
docs: Fix incorrect property description

### DIFF
--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -273,7 +273,7 @@ export type SearchOptions = {
   readonly aroundLatLngViaIP?: boolean;
 
   /**
-   * Search for entries around a given location automatically computed from the requester’s IP address.
+   * Define the maximum radius for a geo search (in meters).
    */
   readonly aroundRadius?: number | 'all';
 


### PR DESCRIPTION
This text is a mistake. `aroundRadius` is not for IP address searches
only.

Copied the text from [here](https://www.algolia.com/doc/api-reference/api-parameters/aroundRadius/).
