### PR TITLE
fix ```algoliaserch/lite``` export from ```lite.esm.browser```

### DIFF
--- a/packages/algoliasearch/lite.js
+++ b/packages/algoliasearch/lite.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line functional/immutable-data, import/no-commonjs
-module.exports = require('./index');
+module.exports = require('./dist/algoliasearch-lite.esm.browser');


### PR DESCRIPTION
Fix #1445