### PR TITLE
feat(neuralsearch): adding the semanticSearch settings to client-search

### DIFF
--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -311,6 +311,13 @@ export type Settings = {
   readonly mode?: 'neuralSearch' | 'keywordSearch';
 
   /**
+   * The settings relevant for configuration of the semantic search engine.
+   */
+  readonly semanticSearch?: {
+    readonly eventSources?: readonly string[];
+  };
+
+  /**
    * Content defining how the search interface should be rendered.
    * This is set via the settings for a default value and can be overridden via rules
    */

--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -312,6 +312,7 @@ export type Settings = {
 
   /**
    * The settings relevant for configuration of the semantic search engine.
+   * These settings are only used when the mode is set to 'neuralSearch'.
    */
   readonly semanticSearch?: {
     readonly eventSources?: readonly string[];


### PR DESCRIPTION
## What

Update the existing typing to include `semanticSearch` with `eventSources` for configuring NeuralSearch.

## Why

RFC: https://algolia.atlassian.net/wiki/spaces/NEUR/pages/4507369495/Event+Sources+for+Neural+Search

