### PR TITLE
FEAT: Removing Mode for CloudFlare Workers

### DIFF
--- a/packages/requester-fetch/src/createFetchRequester.ts
+++ b/packages/requester-fetch/src/createFetchRequester.ts
@@ -44,7 +44,6 @@ export function createFetchRequester({
             ...request.headers,
           },
           body: request.data || null,
-          mode: 'cors',
           redirect: 'manual',
           signal,
         });


### PR DESCRIPTION
## Description

When trying to use Algolia's `requester-fetch` package combined with the `algoliasearch` method on Cloudflare workers, we get the error `The 'mode' field on 'RequestInitializerDict' is not implemented.`. For reference CF workers are ran in V8 Isolate and they have not added an implementation for mode on their fetch runtime.

Although it's not ideal that the behaviour of CloudFlare is to throw an error, we can avoid this issue by removing the mode field from the `requester-fetch` fetch options. The default mode is `cors` anyway so there is no functional change.

This issue has surfaced for multiple people as seen in [this forum](https://discourse.algolia.com/t/cloudflare-workers-and-algoliasearch-javascript-problem/16714).

## Reasons

I looked at the other request packages but they do not fit the bill.

- `requester-node-http`: CF workers are ran in a browser environment not node
- `requester-browser-xhr`: `XMLHttpRequest` is not implemented on CF workers.