### PR TITLE
feat(neural): make eventSources nullable

### DIFF
--- a/packages/client-search/src/types/Settings.ts
+++ b/packages/client-search/src/types/Settings.ts
@@ -315,7 +315,10 @@ export type Settings = {
    * These settings are only used when the mode is set to 'neuralSearch'.
    */
   readonly semanticSearch?: {
-    readonly eventSources?: readonly string[];
+    /**
+     * When null, the current index / replica group will be used as the event source.
+     */
+    readonly eventSources?: readonly string[] | null;
   };
 
   /**


### PR DESCRIPTION
## Why

Explicit nullable type for the `eventSources` setting. This is helpful since the `null` state is the 'default' for the field, and nulling the value has specific behavior in the search engine (e.g. to use the primary/replica index group as event sources).

