### PR TITLE
feat(neuralsearch): Update ab test typing for prefix and suffix retrieval

### DIFF
--- a/packages/client-analytics/src/types/GetABTestsOptions.ts
+++ b/packages/client-analytics/src/types/GetABTestsOptions.ts
@@ -8,4 +8,16 @@ export type GetABTestsOptions = {
    *  The limit of the number of ab tests returned.
    */
   readonly limit?: number;
+
+  /**
+   *  Filters the returned ab tests by any indices starting with the
+   *  provided prefix that are assigned to either variant of an ab test.
+   */
+  readonly indexPrefix?: string;
+
+  /**
+   *  Filters the returned ab tests by any indices ending with the
+   *  provided suffix that are assigned to either variant of an ab test.
+   */
+  readonly indexSuffix?: string;
 };


### PR DESCRIPTION
## Summary

Ref: https://github.com/algolia/go/pull/10733

https://algolia.atlassian.net/wiki/spaces/GR/pages/4518510769/List+A+B+test+index+variant+prefix

[SCC-443]

Updating the typing of the GET for retrieving all ab tests to add the new `indexPrefix` and `indexSuffix` query parameters to facilitate getting specific indices for the dashboard as part of the neuralsearch integration.

[SCC-443]: https://algolia.atlassian.net/browse/SCC-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ