### PR TITLE
feat(cache-browser-local-storage): Implemented TTL support to cached items

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "8.1KB"
+      "maxSize": "8.2KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",

--- a/package.json
+++ b/package.json
@@ -98,15 +98,15 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "8KB"
+      "maxSize": "8.1KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",
-      "maxSize": "4.4KB"
+      "maxSize": "4.6KB"
     },
     {
       "path": "packages/recommend/dist/recommend.umd.js",
-      "maxSize": "4.2KB"
+      "maxSize": "4.3KB"
     }
   ]
 }

--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -27,12 +27,20 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     const timeToLive = options.ttl ? options.ttl * 1000 : null;
     const namespace = getNamespace<BrowserLocalStorageCacheItem>();
 
+    const filteredNamespaceWithoutOldFormattedCacheItems = Object.fromEntries(
+      Object.entries(namespace).filter(([, cacheItem]) => {
+        return cacheItem.timestamp !== undefined;
+      })
+    );
+
+    setNamespace(filteredNamespaceWithoutOldFormattedCacheItems);
+
     if (!timeToLive) {
       return;
     }
 
-    const filteredNamespace = Object.fromEntries(
-      Object.entries(namespace).filter(([, cacheItem]) => {
+    const filteredNamespaceWithoutExpiredItems = Object.fromEntries(
+      Object.entries(filteredNamespaceWithoutOldFormattedCacheItems).filter(([, cacheItem]) => {
         const currentTimestamp = new Date().getTime();
         const isExpired = cacheItem.timestamp + timeToLive < currentTimestamp;
 
@@ -40,7 +48,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
       })
     );
 
-    setNamespace(filteredNamespace);
+    setNamespace(filteredNamespaceWithoutExpiredItems);
   };
 
   return {

--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -35,9 +35,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
 
     setNamespace(filteredNamespaceWithoutOldFormattedCacheItems);
 
-    if (!timeToLive) {
-      return;
-    }
+    if (!timeToLive) return;
 
     const filteredNamespaceWithoutExpiredItems = Object.fromEntries(
       Object.entries(filteredNamespaceWithoutOldFormattedCacheItems).filter(([, cacheItem]) => {

--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -24,7 +24,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
   };
 
   const removeOutdatedCacheItems = () => {
-    const timeToLive = options.ttl ? options.ttl * 1000 : null;
+    const timeToLive = options.timeToLive ? options.timeToLive * 1000 : null;
     const namespace = getNamespace<BrowserLocalStorageCacheItem>();
 
     const filteredNamespaceWithoutOldFormattedCacheItems = Object.fromEntries(

--- a/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
+++ b/packages/cache-browser-local-storage/src/createBrowserLocalStorageCache.ts
@@ -1,6 +1,6 @@
 import { Cache, CacheEvents } from '@algolia/cache-common';
 
-import { BrowserLocalStorageOptions } from '.';
+import { BrowserLocalStorageCacheItem, BrowserLocalStorageOptions } from '.';
 
 export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptions): Cache {
   const namespaceKey = `algoliasearch-client-js-${options.key}`;
@@ -19,6 +19,30 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     return JSON.parse(getStorage().getItem(namespaceKey) || '{}');
   };
 
+  const setNamespace = (namespace: Record<string, any>) => {
+    getStorage().setItem(namespaceKey, JSON.stringify(namespace));
+  };
+
+  const removeOutdatedCacheItems = () => {
+    const timeToLive = options.ttl ? options.ttl * 1000 : null;
+    const namespace = getNamespace<BrowserLocalStorageCacheItem>();
+
+    if (!timeToLive) {
+      return;
+    }
+
+    const filteredNamespace = Object.fromEntries(
+      Object.entries(namespace).filter(([, cacheItem]) => {
+        const currentTimestamp = new Date().getTime();
+        const isExpired = cacheItem.timestamp + timeToLive < currentTimestamp;
+
+        return !isExpired;
+      })
+    );
+
+    setNamespace(filteredNamespace);
+  };
+
   return {
     get<TValue>(
       key: object | string,
@@ -29,10 +53,14 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     ): Readonly<Promise<TValue>> {
       return Promise.resolve()
         .then(() => {
-          const keyAsString = JSON.stringify(key);
-          const value = getNamespace<TValue>()[keyAsString];
+          removeOutdatedCacheItems();
 
-          return Promise.all([value || defaultValue(), value !== undefined]);
+          const keyAsString = JSON.stringify(key);
+
+          return getNamespace<Promise<BrowserLocalStorageCacheItem>>()[keyAsString];
+        })
+        .then(value => {
+          return Promise.all([value ? value.value : defaultValue(), value !== undefined]);
         })
         .then(([value, exists]) => {
           return Promise.all([value, exists || events.miss(value)]);
@@ -45,7 +73,10 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
         const namespace = getNamespace();
 
         // eslint-disable-next-line functional/immutable-data
-        namespace[JSON.stringify(key)] = value;
+        namespace[JSON.stringify(key)] = {
+          timestamp: new Date().getTime(),
+          value,
+        };
 
         getStorage().setItem(namespaceKey, JSON.stringify(namespace));
 

--- a/packages/cache-browser-local-storage/src/types/BrowserLocalStorageCacheItem.ts
+++ b/packages/cache-browser-local-storage/src/types/BrowserLocalStorageCacheItem.ts
@@ -1,0 +1,11 @@
+export type BrowserLocalStorageCacheItem = {
+  /**
+   * The cache item creation timestamp.
+   */
+  readonly timestamp: number;
+
+  /**
+   * The cache item value
+   */
+  readonly value: any;
+};

--- a/packages/cache-browser-local-storage/src/types/BrowserLocalStorageOptions.ts
+++ b/packages/cache-browser-local-storage/src/types/BrowserLocalStorageOptions.ts
@@ -5,6 +5,11 @@ export type BrowserLocalStorageOptions = {
   readonly key: string;
 
   /**
+   * The time to live for each cached item in seconds.
+   */
+  readonly ttl?: number;
+
+  /**
    * The native local storage implementation.
    */
   readonly localStorage?: Storage;

--- a/packages/cache-browser-local-storage/src/types/BrowserLocalStorageOptions.ts
+++ b/packages/cache-browser-local-storage/src/types/BrowserLocalStorageOptions.ts
@@ -7,7 +7,7 @@ export type BrowserLocalStorageOptions = {
   /**
    * The time to live for each cached item in seconds.
    */
-  readonly ttl?: number;
+  readonly timeToLive?: number;
 
   /**
    * The native local storage implementation.

--- a/packages/cache-browser-local-storage/src/types/index.ts
+++ b/packages/cache-browser-local-storage/src/types/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './BrowserLocalStorageOptions';
+export * from './BrowserLocalStorageCacheItem';


### PR DESCRIPTION
## Feature summary
This introduces the ability to set a TTL for cached items, in order to reduce the size of this cache and prevents the cache from permanently holding onto the items.

This feature is optional, and if the `timeToLive` option is not configured, it will behave like how it currently does.

## Why?
We ran into storage quotas, and saw that this cache can grow to a couple MB after a while. We made our own patched version, but it would be nice if this feature was implemented upstream.

Providing this fix in the form of a pull request was discussed via the [support.algolia.com/hc/requests/551781](http://support.algolia.com/hc/requests/551781) support ticket.