### PR TITLE
fix(recommend): Align `getRecommendations` type with actual implementation

### DIFF
--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -1,21 +1,11 @@
 import { MethodEnum } from '@algolia/requester-common';
 
-import {
-  BaseRecommendClient,
-  RecommendationsQuery,
-  TrendingFacetsQuery,
-  TrendingItemsQuery,
-  TrendingModel,
-  WithRecommendMethods,
-} from '../types';
+import { BaseRecommendClient, RecommendationsQuery, WithRecommendMethods } from '../types';
+import { TrendingQuery } from '../types/TrendingQuery';
 
 type GetRecommendations = (
   base: BaseRecommendClient
 ) => WithRecommendMethods<BaseRecommendClient>['getRecommendations'];
-
-type TrendingQuery =
-  | (TrendingItemsQuery & { readonly model: TrendingModel })
-  | (TrendingFacetsQuery & { readonly model: TrendingModel });
 
 export const getRecommendations: GetRecommendations = base => {
   return (queries: ReadonlyArray<RecommendationsQuery | TrendingQuery>, requestOptions) => {

--- a/packages/recommend/src/types/TrendingQuery.ts
+++ b/packages/recommend/src/types/TrendingQuery.ts
@@ -1,0 +1,7 @@
+import { TrendingFacetsQuery } from '../types/TrendingFacetsQuery';
+import { TrendingItemsQuery } from '../types/TrendingItemsQuery';
+import { TrendingModel } from './RecommendModel';
+
+export type TrendingQuery =
+  | (TrendingItemsQuery & { readonly model: TrendingModel })
+  | (TrendingFacetsQuery & { readonly model: TrendingModel });

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -6,13 +6,14 @@ import { RecommendationsQuery } from './RecommendationsQuery';
 import { RelatedProductsQuery } from './RelatedProductsQuery';
 import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
+import { TrendingQuery } from './TrendingQuery';
 
 export type WithRecommendMethods<TType> = TType & {
   /**
    * Returns recommendations.
    */
   readonly getRecommendations: <TObject>(
-    queries: readonly RecommendationsQuery[],
+    queries: ReadonlyArray<RecommendationsQuery | TrendingQuery>,
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
 

--- a/packages/recommend/src/types/index.ts
+++ b/packages/recommend/src/types/index.ts
@@ -12,4 +12,5 @@ export * from './RecommendationsQuery';
 export * from './RelatedProductsQuery';
 export * from './TrendingFacetsQuery';
 export * from './TrendingItemsQuery';
+export * from './TrendingQuery';
 export * from './WithRecommendMethods';


### PR DESCRIPTION
As defined in `getRecommendations.ts`, a `query` is defined as `ReadonlyArray<RecommendationsQuery | TrendingQuery>` 

But in `WithRecommendMethods.ts` it seems that the definition is outdated.


Should help get the PR https://github.com/algolia/recommend/pull/131 moving.