### PR TITLE
fix(types): union SearchForFacetValuesResponse type for multipleQueries

### DIFF
--- a/packages/client-search/src/__tests__/integration/multiple-operations.test.ts
+++ b/packages/client-search/src/__tests__/integration/multiple-operations.test.ts
@@ -1,6 +1,12 @@
 import { BatchActionEnum, StrategyEnum } from '../..';
 import { TestSuite } from '../../../../client-common/src/__tests__/TestSuite';
-import { MultipleBatchRequest } from '../../types';
+import { MultipleBatchRequest, MultipleQueriesResponse, SearchResponse } from '../../types';
+
+function expectSearchResponse<TObject>(
+  results: MultipleQueriesResponse<TObject>['results'][number]
+): asserts results is SearchResponse<TObject> {
+  expect(results).toHaveProperty('hits');
+}
 
 const testSuite = new TestSuite('multiple_operations');
 
@@ -62,7 +68,9 @@ test(testSuite.testName, async () => {
     { strategy: StrategyEnum.None }
   );
 
+  expectSearchResponse(multipleQueriesResponse1.results[0]);
   expect(multipleQueriesResponse1.results[0].hits).toHaveLength(2);
+  expectSearchResponse(multipleQueriesResponse1.results[1]);
   expect(multipleQueriesResponse1.results[1].hits).toHaveLength(2);
 
   const multipleQueriesResponse2 = await client.search(
@@ -73,7 +81,9 @@ test(testSuite.testName, async () => {
     { strategy: StrategyEnum.StopIfEnoughMatches }
   );
 
+  expectSearchResponse(multipleQueriesResponse2.results[0]);
   expect(multipleQueriesResponse2.results[0].hits).toHaveLength(2);
+  expectSearchResponse(multipleQueriesResponse2.results[1]);
   expect(multipleQueriesResponse2.results[1].hits).toHaveLength(0);
 
   const searchForFacetValuesResponse = await client.searchForFacetValues([

--- a/packages/client-search/src/types/MultipleQueriesResponse.ts
+++ b/packages/client-search/src/types/MultipleQueriesResponse.ts
@@ -1,8 +1,9 @@
 import { SearchResponse } from '.';
+import { SearchForFacetValuesResponse } from './SearchForFacetValuesResponse';
 
 export type MultipleQueriesResponse<TObject> = {
   /**
    * The list of results.
    */
-  results: Array<SearchResponse<TObject>>;
+  results: Array<SearchResponse<TObject> | SearchForFacetValuesResponse>;
 };

--- a/packages/client-search/src/types/MultipleQueriesResponse.ts
+++ b/packages/client-search/src/types/MultipleQueriesResponse.ts
@@ -1,5 +1,4 @@
-import { SearchResponse } from '.';
-import { SearchForFacetValuesResponse } from './SearchForFacetValuesResponse';
+import { SearchForFacetValuesResponse, SearchResponse } from '.';
 
 export type MultipleQueriesResponse<TObject> = {
   /**


### PR DESCRIPTION
## Summary

This PR unions `SearchForFacetValuesResponse` with `SearchResponse<TObject>` as possible return types for results in the `multipleQueries` API.

## Context

The `MultipleQueriesQuery` interface [states](https://github.com/algolia/algoliasearch-client-javascript/blob/4.13.0/packages/client-search/src/types/MultipleQueriesQuery.ts#L27-L48) that you can supply either a `default` or a `facet` query. This is also confirmed by the Algolia [documentation.](https://www.algolia.com/doc/api-reference/api-methods/multiple-queries/#method-param-type)

However, the MultipleQueriesResponse [definition](https://github.com/algolia/algoliasearch-client-javascript/blob/4.13.0/packages/client-search/src/types/MultipleQueriesResponse.ts#LL7C18-L7C32) does not include [SearchForFacetValuesResponse](https://github.com/algolia/algoliasearch-client-javascript/blob/4.13.0/packages/client-search/src/types/SearchForFacetValuesResponse.ts) as a possible return type. This is confusing because the response data from Algolia does in fact include facet responses when requested (see attached image).

![image](https://github.com/algolia/algoliasearch-client-javascript/assets/16735699/f753b79d-98c7-4ead-a202-8fe0f80b44b8)