### PR TITLE
docs: Fix incorrect property description

### DIFF
--- a/packages/client-search/src/types/SearchOptions.ts
+++ b/packages/client-search/src/types/SearchOptions.ts
@@ -253,7 +253,7 @@ export type SearchOptions = {
   readonly restrictSearchableAttributes?: readonly string[];
 
   /**
-   * Restricts a given query to look in only a subset of your searchable attributes.
+   * Controls how facet values are sorted.
    */
   readonly sortFacetValuesBy?: 'count' | 'alpha';
 


### PR DESCRIPTION
The `sortFacetValuesBy` property had the same description as the `restrictSearchableAttributes` property above it. I copied the new property description [from here](https://github.com/algolia/algoliasearch-client-javascript/blob/eacfca290813eac98211b0da3c78c41393977c37/packages/client-search/src/types/Settings.ts#L59-L62).