### PR TITLE
fix(search): fix wait method for updateApiKey request

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.95KB"
+      "maxSize": "8KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",


### PR DESCRIPTION
Fix the `wait` method of the `updateApiKey` request so it really waits for an update on the key instead of directly resolving.