### PR TITLE
feat(abtests): add outlier count to variant response payload

### DIFF
--- a/packages/client-analytics/src/types/VariantResponse.ts
+++ b/packages/client-analytics/src/types/VariantResponse.ts
@@ -48,6 +48,16 @@ export type VariantResponse = Variant & {
    */
   userCount?: number;
 
+  /**
+   * Count of the tracked searches attributed to outlier traffic that were removed from the A/B test.
+   */
+  outlierTrackedSearchesCount?: number;
+
+  /**
+   * Count of users attributed to outlier traffic that were removed from the A/B test.
+   */
+  outlierUsersCount?: number;
+
   // @todo Handle this search options type.
   /**
    * The search parameters.


### PR DESCRIPTION
This PR is a follow up from the one made in the generated clients (https://github.com/algolia/api-clients-automation/pull/1656) to allow using them in the dashboard immediately.

[SCC-671]

[SCC-671]: https://algolia.atlassian.net/browse/SCC-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ