### PR TITLE
fix(recommend): Add Type RecommendQueriesResponse from old MultipleQueriesResponse for recommend

### DIFF
--- a/packages/recommend/src/__tests__/getRecommendations.test.ts
+++ b/packages/recommend/src/__tests__/getRecommendations.test.ts
@@ -2,9 +2,21 @@ import { TestSuite } from '../../../client-common/src/__tests__/TestSuite';
 
 const recommend = new TestSuite('recommend').recommend;
 
-function createMockedClient() {
+function createMockedClient<TObject>() {
   const client = recommend('appId', 'apiKey');
-  jest.spyOn(client.transporter, 'read').mockImplementation(() => Promise.resolve());
+  jest.spyOn(client.transporter, 'read').mockImplementation(() =>
+    Promise.resolve({
+      results: [
+        {
+          hits: [
+            {
+              objectID: '1',
+            },
+          ],
+        },
+      ],
+    })
+  );
 
   return client;
 }
@@ -196,5 +208,26 @@ describe('getRecommendations', () => {
       },
       {}
     );
+  });
+
+  test('returns recommendations results', async () => {
+    const client = createMockedClient();
+
+    const recommendations = await client.getRecommendations<any>(
+      [
+        {
+          model: 'bought-together',
+          indexName: 'products',
+          objectID: 'B018APC4LE',
+        },
+      ],
+      {}
+    );
+
+    expect(recommendations.results[0].hits).toEqual([
+      {
+        objectID: '1',
+      },
+    ]);
   });
 });

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -9,10 +9,7 @@ import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
 import { TrendingQuery } from './TrendingQuery';
 
-/**
- * This MultipleQueriesResponse type differs from MultipleQueriesResponse imported from @algolia/client-search as it omits "SearchForFacetValuesResponse" in results
- */
-export type MultipleQueriesResponse<TObject> = {
+export type RecommendQueriesResponse<TObject> = {
   /**
    * The list of results.
    */
@@ -26,7 +23,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getRecommendations: <TObject>(
     queries: ReadonlyArray<RecommendationsQuery | TrendingQuery>,
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
   /**
    * Returns [Related Products](https://algolia.com/doc/guides/algolia-ai/recommend/#related-products).
@@ -34,7 +31,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getRelatedProducts: <TObject>(
     queries: readonly RelatedProductsQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
   /**
    * Returns [Frequently Bought Together](https://algolia.com/doc/guides/algolia-ai/recommend/#frequently-bought-together) products.
@@ -42,7 +39,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getFrequentlyBoughtTogether: <TObject>(
     queries: readonly FrequentlyBoughtTogetherQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
   /**
    * Returns trending items
@@ -50,7 +47,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getTrendingItems: <TObject>(
     queries: readonly TrendingItemsQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
   /**
    * Returns trending items per facet
@@ -58,7 +55,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getTrendingFacets: <TObject>(
     queries: readonly TrendingFacetsQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
   /**
    * Returns Looking Similar
@@ -66,5 +63,5 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getLookingSimilar: <TObject>(
     queries: readonly LookingSimilarQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<MultipleQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 };

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -1,4 +1,4 @@
-import { MultipleQueriesResponse, SearchOptions } from '@algolia/client-search';
+import { SearchOptions, SearchResponse } from '@algolia/client-search';
 import { RequestOptions } from '@algolia/transporter';
 
 import { FrequentlyBoughtTogetherQuery } from './FrequentlyBoughtTogetherQuery';
@@ -8,6 +8,16 @@ import { RelatedProductsQuery } from './RelatedProductsQuery';
 import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
 import { TrendingQuery } from './TrendingQuery';
+
+/**
+ * This MultipleQueriesResponse type differs from MultipleQueriesResponse imported from @algolia/client-search as it omits "SearchForFacetValuesResponse" in results
+ */
+export type MultipleQueriesResponse<TObject> = {
+  /**
+   * The list of results.
+   */
+  readonly results: ReadonlyArray<SearchResponse<TObject>>;
+};
 
 export type WithRecommendMethods<TType> = TType & {
   /**


### PR DESCRIPTION
In recommend add type `MultipleQueriesResponse` that basically reverts back to the old definition before PR https://github.com/algolia/algoliasearch-client-javascript/pull/1460