### PR TITLE
feat(search): add inference ACL to API key object

### DIFF
--- a/packages/client-search/src/types/ApiKeyType.ts
+++ b/packages/client-search/src/types/ApiKeyType.ts
@@ -5,6 +5,7 @@ export const ApiKeyACLEnum: Readonly<Record<string, ApiKeyACLType>> = {
   DeleteIndex: 'deleteIndex',
   DeleteObject: 'deleteObject',
   EditSettings: 'editSettings',
+  Inference: 'inference',
   ListIndexes: 'listIndexes',
   Logs: 'logs',
   Personalization: 'personalization',
@@ -22,6 +23,7 @@ export type ApiKeyACLType =
   | 'deleteIndex'
   | 'deleteObject'
   | 'editSettings'
+  | 'inference'
   | 'listIndexes'
   | 'logs'
   | 'personalization'


### PR DESCRIPTION
This is a follow up change to a change made in the generated clients (https://github.com/algolia/api-clients-automation/pull/1985) so it can be used the dashboard.

[AIE-512](https://algolia.atlassian.net/browse/AIE-512)

[AIE-512]: https://algolia.atlassian.net/browse/AIE-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ