### PR TITLE
Fix/recommend get trending facets typing

### DIFF
--- a/packages/recommend/src/types/TrendingFacetHit.ts
+++ b/packages/recommend/src/types/TrendingFacetHit.ts
@@ -1,0 +1,5 @@
+export type TrendingFacetHit<TObject> = {
+  readonly _score: number;
+  readonly facetName: string;
+  readonly facetValue: TObject;
+};

--- a/packages/recommend/src/types/TrendingFacetsResponse.ts
+++ b/packages/recommend/src/types/TrendingFacetsResponse.ts
@@ -1,0 +1,7 @@
+import { SearchResponse } from '@algolia/client-search';
+
+import { TrendingFacetHit } from './TrendingFacetHit';
+
+export type TrendingFacetsResponse<TObject> = Omit<SearchResponse<TObject>, 'hits'> & {
+  readonly hits: ReadonlyArray<TrendingFacetHit<TObject>>;
+};

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -6,18 +6,9 @@ import { LookingSimilarQuery } from './LookingSimilarQuery';
 import { RecommendationsQuery } from './RecommendationsQuery';
 import { RelatedProductsQuery } from './RelatedProductsQuery';
 import { TrendingFacetsQuery } from './TrendingFacetsQuery';
+import { TrendingFacetsResponse } from './TrendingFacetsResponse';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
 import { TrendingQuery } from './TrendingQuery';
-
-export type TrendingFacetHit<TObject> = {
-  readonly _score: number;
-  readonly facetName: string;
-  readonly facetValue: TObject;
-};
-
-export type TrendingFacetsResponse<TObject> = Omit<SearchResponse<TObject>, 'hits'> & {
-  readonly hits: ReadonlyArray<TrendingFacetHit<TObject>>;
-};
 
 export type RecommendTrendingFacetsQueriesResponse<TObject> = {
   /**

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -9,6 +9,23 @@ import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
 import { TrendingQuery } from './TrendingQuery';
 
+export type TrendingFacetHit<TObject> = {
+  readonly _score: number;
+  readonly facetName: string;
+  readonly facetValue: TObject;
+};
+
+export type TrendingFacetsResponse<TObject> = Omit<SearchResponse<TObject>, 'hits'> & {
+  readonly hits: ReadonlyArray<TrendingFacetHit<TObject>>;
+};
+
+export type RecommendTrendingFacetsQueriesResponse<TObject> = {
+  /**
+   * The list of results.
+   */
+  readonly results: ReadonlyArray<TrendingFacetsResponse<TObject>>;
+};
+
 export type RecommendQueriesResponse<TObject> = {
   /**
    * The list of results.

--- a/packages/recommend/src/types/index.ts
+++ b/packages/recommend/src/types/index.ts
@@ -15,3 +15,5 @@ export * from './TrendingItemsQuery';
 export * from './TrendingQuery';
 export * from './WithRecommendMethods';
 export * from './LookingSimilarQuery';
+export * from './TrendingFacetHit';
+export * from './TrendingFacetsResponse';


### PR DESCRIPTION
The `hits` returned by `getTrendingFacets` differ (they only have `faceValue`, `facetName` and `_score`) from the normal hits returned by the other recommendation methods.