### PR TITLE
fix(recommend): RecommendedForYouQuery `userToken` should be required

### DIFF
--- a/packages/recommend/src/types/RecommendedForYouQuery.ts
+++ b/packages/recommend/src/types/RecommendedForYouQuery.ts
@@ -1,3 +1,19 @@
 import { RecommendationsQuery } from './RecommendationsQuery';
+import { RecommendSearchOptions } from './RecommendSearchOptions';
 
-export type RecommendedForYouQuery = Omit<RecommendationsQuery, 'model' | 'objectID'>;
+export type RecommendedForYouQuery = Omit<
+  RecommendationsQuery,
+  'model' | 'objectID' | 'queryParameters'
+> & {
+  /**
+   * List of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/) to send.
+   */
+  readonly queryParameters: Omit<RecommendSearchOptions, 'userToken'> & {
+    /**
+     * A user identifier.
+     * Format: alpha numeric string [a-zA-Z0-9_-]
+     * Length: between 1 and 64 characters.
+     */
+    readonly userToken: string;
+  };
+};


### PR DESCRIPTION
For the model `recommended-for-you` the `userToken` parameter is not optional otherwise the API will throw an error: 

![image](https://github.com/algolia/algoliasearch-client-javascript/assets/1442690/db9da80c-0315-4eb5-ae39-8bd13129e433)
