### PR TITLE
fix(recommend): update TrendingFacetHit facetValue type to string

### DIFF
--- a/packages/recommend/src/types/TrendingFacetHit.ts
+++ b/packages/recommend/src/types/TrendingFacetHit.ts
@@ -1,5 +1,5 @@
-export type TrendingFacetHit<TObject> = {
+export type TrendingFacetHit = {
   readonly _score: number;
   readonly facetName: string;
-  readonly facetValue: TObject;
+  readonly facetValue: string;
 };

--- a/packages/recommend/src/types/TrendingFacetsResponse.ts
+++ b/packages/recommend/src/types/TrendingFacetsResponse.ts
@@ -2,6 +2,6 @@ import { SearchResponse } from '@algolia/client-search';
 
 import { TrendingFacetHit } from './TrendingFacetHit';
 
-export type TrendingFacetsResponse<TObject> = Omit<SearchResponse<TObject>, 'hits'> & {
-  readonly hits: ReadonlyArray<TrendingFacetHit<TObject>>;
+export type TrendingFacetsResponse = Omit<SearchResponse, 'hits'> & {
+  readonly hits: readonly TrendingFacetHit[];
 };

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -11,11 +11,11 @@ import { TrendingFacetsResponse } from './TrendingFacetsResponse';
 import { TrendingItemsQuery } from './TrendingItemsQuery';
 import { TrendingQuery } from './TrendingQuery';
 
-export type RecommendTrendingFacetsQueriesResponse<TObject> = {
+export type RecommendTrendingFacetsQueriesResponse = {
   /**
    * The list of results.
    */
-  readonly results: ReadonlyArray<TrendingFacetsResponse<TObject>>;
+  readonly results: readonly TrendingFacetsResponse[];
 };
 
 export type RecommendQueriesResponse<TObject> = {
@@ -64,7 +64,7 @@ export type WithRecommendMethods<TType> = TType & {
   readonly getTrendingFacets: <TObject>(
     queries: readonly TrendingFacetsQuery[],
     requestOptions?: RequestOptions & SearchOptions
-  ) => Readonly<Promise<RecommendTrendingFacetsQueriesResponse<TObject>>>;
+  ) => Readonly<Promise<RecommendTrendingFacetsQueriesResponse>>;
 
   /**
    * Returns Looking Similar


### PR DESCRIPTION
The `trending-facets` API will only return type `string` for `facetValue`. 

To simplify the code, we can remove the type argument `TObject` for `trending-facets` 