### PR TITLE
fix(recommend): update recommended-for-you model type

### DIFF
--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -1,27 +1,14 @@
 import { MethodEnum } from '@algolia/requester-common';
 
-import {
-  BaseRecommendClient,
-  RecommendationsQuery,
-  RecommendationsQueryWithoutObjectID,
-  WithRecommendMethods,
-} from '../types';
-import { TrendingQuery } from '../types/TrendingQuery';
+import { BaseRecommendClient, WithRecommendMethods } from '../types';
 
 type GetRecommendations = (
   base: BaseRecommendClient
 ) => WithRecommendMethods<BaseRecommendClient>['getRecommendations'];
 
 export const getRecommendations: GetRecommendations = base => {
-  return (
-    queries: ReadonlyArray<
-      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
-    >,
-    requestOptions
-  ) => {
-    const requests: ReadonlyArray<
-      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
-    > = queries.map(query => ({
+  return (queries, requestOptions) => {
+    const requests = queries.map(query => ({
       ...query,
       // The `threshold` param is required by the endpoint to make it easier
       // to provide a default value later, so we default it in the client

--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -3,7 +3,7 @@ import { MethodEnum } from '@algolia/requester-common';
 import {
   BaseRecommendClient,
   RecommendationsQuery,
-  RecommendedForYouQuery,
+  RecommendationsQueryWithoutObjectID,
   WithRecommendMethods,
 } from '../types';
 import { TrendingQuery } from '../types/TrendingQuery';
@@ -13,9 +13,14 @@ type GetRecommendations = (
 ) => WithRecommendMethods<BaseRecommendClient>['getRecommendations'];
 
 export const getRecommendations: GetRecommendations = base => {
-  return (queries: ReadonlyArray<RecommendationsQuery | TrendingQuery>, requestOptions) => {
+  return (
+    queries: ReadonlyArray<
+      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
+    >,
+    requestOptions
+  ) => {
     const requests: ReadonlyArray<
-      RecommendationsQuery | TrendingQuery | RecommendedForYouQuery
+      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
     > = queries.map(query => ({
       ...query,
       // The `threshold` param is required by the endpoint to make it easier

--- a/packages/recommend/src/methods/getRecommendations.ts
+++ b/packages/recommend/src/methods/getRecommendations.ts
@@ -1,6 +1,12 @@
 import { MethodEnum } from '@algolia/requester-common';
 
-import { BaseRecommendClient, WithRecommendMethods } from '../types';
+import {
+  BaseRecommendClient,
+  RecommendationsQuery,
+  RecommendedForYouQuery,
+  TrendingQuery,
+  WithRecommendMethods,
+} from '../types';
 
 type GetRecommendations = (
   base: BaseRecommendClient
@@ -8,7 +14,9 @@ type GetRecommendations = (
 
 export const getRecommendations: GetRecommendations = base => {
   return (queries, requestOptions) => {
-    const requests = queries.map(query => ({
+    const requests: ReadonlyArray<
+      RecommendationsQuery | TrendingQuery | RecommendedForYouQuery
+    > = queries.map(query => ({
       ...query,
       // The `threshold` param is required by the endpoint to make it easier
       // to provide a default value later, so we default it in the client

--- a/packages/recommend/src/methods/getRecommendedForYou.ts
+++ b/packages/recommend/src/methods/getRecommendedForYou.ts
@@ -1,13 +1,18 @@
 import { MethodEnum } from '@algolia/requester-common';
 
-import { BaseRecommendClient, RecommendedForYouQuery, WithRecommendMethods } from '../types';
+import {
+  BaseRecommendClient,
+  RecommendedForYouParams,
+  RecommendedForYouQuery,
+  WithRecommendMethods,
+} from '../types';
 
 type GetRecommendedForYou = (
   base: BaseRecommendClient
 ) => WithRecommendMethods<BaseRecommendClient>['getRecommendedForYou'];
 
 export const getRecommendedForYou: GetRecommendedForYou = base => {
-  return (queries: readonly RecommendedForYouQuery[], requestOptions) => {
+  return (queries: readonly RecommendedForYouParams[], requestOptions) => {
     const requests: readonly RecommendedForYouQuery[] = queries.map(query => ({
       ...query,
       model: 'recommended-for-you',

--- a/packages/recommend/src/types/RecommendationsQuery.ts
+++ b/packages/recommend/src/types/RecommendationsQuery.ts
@@ -1,4 +1,3 @@
-import { RecommendModel } from './RecommendModel';
 import { RecommendSearchOptions } from './RecommendSearchOptions';
 
 export type RecommendationsQuery = {
@@ -10,7 +9,7 @@ export type RecommendationsQuery = {
   /**
    * The name of the Recommendation model to use.
    */
-  readonly model: RecommendModel;
+  readonly model: 'related-products' | 'bought-together' | 'looking-similar';
 
   /**
    * The `objectID` of the item to get recommendations for.

--- a/packages/recommend/src/types/RecommendationsQuery.ts
+++ b/packages/recommend/src/types/RecommendationsQuery.ts
@@ -38,18 +38,3 @@ export type RecommendationsQuery = {
    */
   readonly fallbackParameters?: RecommendSearchOptions;
 };
-
-/**
- * Base type for models that don't require an `objectID`.
- *
- * Currently the only model that doesn't require an `objectID` is `recommended-for-you`.
- */
-export type RecommendationsQueryWithoutObjectID = Omit<
-  RecommendationsQuery,
-  'objectID' | 'model'
-> & {
-  /**
-   * The name of the Recommendation model to use.
-   */
-  readonly model: 'recommended-for-you';
-};

--- a/packages/recommend/src/types/RecommendationsQuery.ts
+++ b/packages/recommend/src/types/RecommendationsQuery.ts
@@ -39,3 +39,18 @@ export type RecommendationsQuery = {
    */
   readonly fallbackParameters?: RecommendSearchOptions;
 };
+
+/**
+ * Base type for models that don't require an `objectID`.
+ *
+ * Currently the only model that doesn't require an `objectID` is `recommended-for-you`.
+ */
+export type RecommendationsQueryWithoutObjectID = Omit<
+  RecommendationsQuery,
+  'objectID' | 'model'
+> & {
+  /**
+   * The name of the Recommendation model to use.
+   */
+  readonly model: 'recommended-for-you';
+};

--- a/packages/recommend/src/types/RecommendedForYouQuery.ts
+++ b/packages/recommend/src/types/RecommendedForYouQuery.ts
@@ -1,10 +1,11 @@
-import { RecommendationsQueryWithoutObjectID } from './RecommendationsQuery';
+import { RecommendationsQuery } from './RecommendationsQuery';
 import { RecommendSearchOptions } from './RecommendSearchOptions';
 
 export type RecommendedForYouQuery = Omit<
-  RecommendationsQueryWithoutObjectID,
-  'model' | 'queryParameters'
+  RecommendationsQuery,
+  'model' | 'objectID' | 'queryParameters'
 > & {
+  readonly model: 'recommended-for-you';
   /**
    * List of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/) to send.
    */
@@ -17,3 +18,8 @@ export type RecommendedForYouQuery = Omit<
     readonly userToken: string;
   };
 };
+
+/**
+ * The parameters used for `getRecommendedForYou` method.
+ */
+export type RecommendedForYouParams = Omit<RecommendedForYouQuery, 'model'>;

--- a/packages/recommend/src/types/RecommendedForYouQuery.ts
+++ b/packages/recommend/src/types/RecommendedForYouQuery.ts
@@ -1,10 +1,11 @@
-import { RecommendationsQuery } from './RecommendationsQuery';
+import { RecommendationsQueryWithoutObjectID } from './RecommendationsQuery';
 import { RecommendSearchOptions } from './RecommendSearchOptions';
 
 export type RecommendedForYouQuery = Omit<
-  RecommendationsQuery,
-  'model' | 'objectID' | 'queryParameters'
+  RecommendationsQueryWithoutObjectID,
+  'model' | 'queryParameters'
 > & {
+  readonly model: 'recommended-for-you';
   /**
    * List of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/) to send.
    */

--- a/packages/recommend/src/types/RecommendedForYouQuery.ts
+++ b/packages/recommend/src/types/RecommendedForYouQuery.ts
@@ -5,7 +5,6 @@ export type RecommendedForYouQuery = Omit<
   RecommendationsQueryWithoutObjectID,
   'model' | 'queryParameters'
 > & {
-  readonly model: 'recommended-for-you';
   /**
    * List of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/) to send.
    */

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -1,10 +1,10 @@
 import { SearchOptions, SearchResponse } from '@algolia/client-search';
 import { RequestOptions } from '@algolia/transporter';
 
-import { RecommendedForYouQuery } from '../builds/node';
+import { RecommendedForYouParams, RecommendedForYouQuery } from '../builds/node';
 import { FrequentlyBoughtTogetherQuery } from './FrequentlyBoughtTogetherQuery';
 import { LookingSimilarQuery } from './LookingSimilarQuery';
-import { RecommendationsQuery, RecommendationsQueryWithoutObjectID } from './RecommendationsQuery';
+import { RecommendationsQuery } from './RecommendationsQuery';
 import { RelatedProductsQuery } from './RelatedProductsQuery';
 import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingFacetsResponse } from './TrendingFacetsResponse';
@@ -30,9 +30,7 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns recommendations.
    */
   readonly getRecommendations: <TObject>(
-    queries: ReadonlyArray<
-      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
-    >,
+    queries: ReadonlyArray<RecommendationsQuery | TrendingQuery | RecommendedForYouQuery>,
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 
@@ -80,7 +78,7 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns Recommended for you
    */
   readonly getRecommendedForYou: <TObject>(
-    queries: readonly RecommendedForYouQuery[],
+    queries: readonly RecommendedForYouParams[],
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 };

--- a/packages/recommend/src/types/WithRecommendMethods.ts
+++ b/packages/recommend/src/types/WithRecommendMethods.ts
@@ -4,7 +4,7 @@ import { RequestOptions } from '@algolia/transporter';
 import { RecommendedForYouQuery } from '../builds/node';
 import { FrequentlyBoughtTogetherQuery } from './FrequentlyBoughtTogetherQuery';
 import { LookingSimilarQuery } from './LookingSimilarQuery';
-import { RecommendationsQuery } from './RecommendationsQuery';
+import { RecommendationsQuery, RecommendationsQueryWithoutObjectID } from './RecommendationsQuery';
 import { RelatedProductsQuery } from './RelatedProductsQuery';
 import { TrendingFacetsQuery } from './TrendingFacetsQuery';
 import { TrendingFacetsResponse } from './TrendingFacetsResponse';
@@ -30,7 +30,9 @@ export type WithRecommendMethods<TType> = TType & {
    * Returns recommendations.
    */
   readonly getRecommendations: <TObject>(
-    queries: ReadonlyArray<RecommendationsQuery | TrendingQuery>,
+    queries: ReadonlyArray<
+      RecommendationsQuery | TrendingQuery | RecommendationsQueryWithoutObjectID
+    >,
     requestOptions?: RequestOptions & SearchOptions
   ) => Readonly<Promise<RecommendQueriesResponse<TObject>>>;
 


### PR DESCRIPTION
When calling `getRecommendations` we need to make sure that the user doesn't have to pass `objectID` for the model `recommended-for-you`.

Otherwise this error will occur: 

```
Property 'objectID' is missing in type '{ indexName: string; model: "recommended-for-you"; fallbackParameters: RecommendSearchOptions | undefined; queryParameters: (RecommendSearchOptions & { ...; }) | undefined; maxRecommendations: number | undefined; }' but required in type 'RecommendationsQuery'.
```` 

The fix should be a patch since the model is not publicly available yet.