### PR TITLE
chore: add-homepage-to-package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "4.22.1",
   "private": true,
   "license": "MIT",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript#readme",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
in vscode for example, the homepage field will show when you hover over a library name in our own package.json