### PR TITLE
feat(analytics): Add trackedUserCount abtest variant

### DIFF
--- a/packages/client-analytics/src/types/VariantResponse.ts
+++ b/packages/client-analytics/src/types/VariantResponse.ts
@@ -44,6 +44,11 @@ export type VariantResponse = Variant & {
   searchCount?: number;
 
   /**
+   * Tracked user count. This is the number of users who performed a tracked search.
+   */
+  trackedUserCount?: number;
+
+  /**
    * User count.
    */
   userCount?: number;


### PR DESCRIPTION
## Summary

[OPTIM-1016]

This PR adds the trackedUserCount to the AB test variant response. These are the distinct number of users that have performed a tracked search.

## Testing

Green CI

[OPTIM-1016]: https://algolia.atlassian.net/browse/OPTIM-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ