### PR TITLE
fix(recommend): remove the search user-agent from requests [RECO-2154]

### DIFF
--- a/packages/recommend/src/__tests__/recommend-client.test.ts
+++ b/packages/recommend/src/__tests__/recommend-client.test.ts
@@ -108,14 +108,12 @@ describe('recommend', () => {
     const client = recommend('appId', 'apiKey');
 
     if (testing.isBrowser()) {
-      expect(client.transporter.userAgent.value).toEqual(
-        `Algolia for JavaScript (${version}); Recommend (${version}); Browser`
-      );
+      expect(client.transporter.userAgent.value).toEqual(`Recommend (${version}); Browser`);
     } else {
       const nodeVersion = process.versions.node;
 
       expect(client.transporter.userAgent.value).toEqual(
-        `Algolia for JavaScript (${version}); Recommend (${version}); Node.js (${nodeVersion})`
+        `Recommend (${version}); Node.js (${nodeVersion})`
       );
     }
   });
@@ -123,7 +121,7 @@ describe('recommend', () => {
   test('allows to customize options', () => {
     const client = recommend('appId', 'apiKey');
     const cache = createInMemoryCache();
-    const userAgent = createUserAgent('0.2.0');
+    const userAgent = createUserAgent('0.2.0', '');
 
     const customClient = recommend('appId', 'apiKey', {
       hostsCache: cache,

--- a/packages/recommend/src/builds/browser.ts
+++ b/packages/recommend/src/builds/browser.ts
@@ -42,7 +42,7 @@ export default function recommend(
         createInMemoryCache(),
       ],
     }),
-    userAgent: createUserAgent(version)
+    userAgent: createUserAgent(version, '')
       .add({ segment: 'Recommend', version })
       .add({ segment: 'Browser' }),
     authMode: AuthMode.WithinQueryParameters,

--- a/packages/recommend/src/builds/node.ts
+++ b/packages/recommend/src/builds/node.ts
@@ -36,7 +36,7 @@ export default function recommend(
     responsesCache: createNullCache(),
     requestsCache: createNullCache(),
     hostsCache: createInMemoryCache(),
-    userAgent: createUserAgent(version)
+    userAgent: createUserAgent(version, '')
       .add({ segment: 'Recommend', version })
       .add({ segment: 'Node.js', version: process.versions.node }),
   };

--- a/packages/transporter/src/createUserAgent.ts
+++ b/packages/transporter/src/createUserAgent.ts
@@ -1,10 +1,12 @@
 import { UserAgent, UserAgentOptions } from '.';
 
-export function createUserAgent(version: string): UserAgent {
+export function createUserAgent(version: string, base = 'Algolia for JavaScript'): UserAgent {
   const userAgent: UserAgent = {
-    value: `Algolia for JavaScript (${version})`,
+    value: base ? `${base} (${version})` : '',
     add(options: UserAgentOptions): UserAgent {
-      const addedUserAgent = `; ${options.segment}${
+      const separator = userAgent.value ? '; ' : '';
+
+      const addedUserAgent = `${separator}${options.segment}${
         options.version !== undefined ? ` (${options.version})` : ''
       }`;
 


### PR DESCRIPTION
## What

The createUserAgent function shouldn't set "Algolia for JavaScript" by default. Instead, this agent should be added in the build of the Search client.

## Why 

> The Recommend client uses the same transporter utilities as the Search client, including the createUserAgent function. This causes it to set the `Algolia for JavaScript` user agent, which corresponds to Algolia Search.

> The Recommend client shouldn't send Algolia Search user agents

## How 

Updated the function `createUserAgent` to accept an optional base UA as a second parameter. Recommend client can set that to an empty string, while the rest can still use the default value `Algolia for JavaScript`