### PR TITLE
feat(search): fetch recommendations directly from algoliasearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "bundlesize": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "8.2KB"
+      "maxSize": "8.4KB"
     },
     {
       "path": "packages/algoliasearch/dist/algoliasearch-lite.umd.js",

--- a/packages/algoliasearch/package.json
+++ b/packages/algoliasearch/package.json
@@ -35,6 +35,7 @@
     "@algolia/client-search": "4.22.1",
     "@algolia/logger-common": "4.22.1",
     "@algolia/logger-console": "4.22.1",
+    "@algolia/recommend": "4.22.1",
     "@algolia/requester-browser-xhr": "4.22.1",
     "@algolia/requester-common": "4.22.1",
     "@algolia/requester-node-http": "4.22.1",

--- a/packages/algoliasearch/src/builds/browser.ts
+++ b/packages/algoliasearch/src/builds/browser.ts
@@ -190,6 +190,16 @@ import {
 } from '@algolia/client-search';
 import { LogLevelEnum } from '@algolia/logger-common';
 import { createConsoleLogger } from '@algolia/logger-console';
+import {
+  getFrequentlyBoughtTogether,
+  getLookingSimilar,
+  getRecommendations,
+  getRecommendedForYou,
+  getRelatedProducts,
+  getTrendingFacets,
+  getTrendingItems,
+  WithRecommendMethods,
+} from '@algolia/recommend';
 import { createBrowserXhrRequester } from '@algolia/requester-browser-xhr';
 import { createUserAgent, Request, RequestOptions } from '@algolia/transporter';
 
@@ -343,6 +353,13 @@ export default function algoliasearch(
 
         return initPersonalization()(clientOptions);
       },
+      getRecommendations,
+      getFrequentlyBoughtTogether,
+      getLookingSimilar,
+      getRecommendedForYou,
+      getRelatedProducts,
+      getTrendingFacets,
+      getTrendingItems,
     },
   });
 }
@@ -689,6 +706,15 @@ export type SearchClient = BaseSearchClient & {
    * @deprecated Use `initPersonalization` instead.
    */
   readonly initRecommendation: (options?: InitPersonalizationOptions) => PersonalizationClient;
+  readonly getRecommendations: WithRecommendMethods<BaseSearchClient>['getRecommendations'];
+  readonly getFrequentlyBoughtTogether: WithRecommendMethods<
+    BaseSearchClient
+  >['getFrequentlyBoughtTogether'];
+  readonly getLookingSimilar: WithRecommendMethods<BaseSearchClient>['getLookingSimilar'];
+  readonly getRecommendedForYou: WithRecommendMethods<BaseSearchClient>['getRecommendedForYou'];
+  readonly getRelatedProducts: WithRecommendMethods<BaseSearchClient>['getRelatedProducts'];
+  readonly getTrendingFacets: WithRecommendMethods<BaseSearchClient>['getTrendingFacets'];
+  readonly getTrendingItems: WithRecommendMethods<BaseSearchClient>['getTrendingItems'];
 };
 
 export * from '../types';

--- a/packages/algoliasearch/src/builds/browserLite.ts
+++ b/packages/algoliasearch/src/builds/browserLite.ts
@@ -25,6 +25,7 @@ import {
 } from '@algolia/client-search';
 import { LogLevelEnum } from '@algolia/logger-common';
 import { createConsoleLogger } from '@algolia/logger-console';
+import { getRecommendations, WithRecommendMethods } from '@algolia/recommend';
 import { createBrowserXhrRequester } from '@algolia/requester-browser-xhr';
 import { createUserAgent, Request, RequestOptions } from '@algolia/transporter';
 
@@ -74,6 +75,7 @@ export default function algoliasearch(
           methods: { search, searchForFacetValues, findAnswers },
         });
       },
+      getRecommendations,
     },
   });
 }
@@ -115,6 +117,7 @@ export type SearchClient = BaseSearchClient & {
     request: Request,
     requestOptions?: RequestOptions
   ) => Readonly<Promise<TResponse>>;
+  readonly getRecommendations: WithRecommendMethods<BaseSearchClient>['getRecommendations'];
 };
 
 export { WithoutCredentials, AlgoliaSearchOptions } from '../types';

--- a/packages/algoliasearch/src/builds/node.ts
+++ b/packages/algoliasearch/src/builds/node.ts
@@ -191,6 +191,16 @@ import {
   waitTask,
 } from '@algolia/client-search';
 import { createNullLogger } from '@algolia/logger-common';
+import {
+  getFrequentlyBoughtTogether,
+  getLookingSimilar,
+  getRecommendations,
+  getRecommendedForYou,
+  getRelatedProducts,
+  getTrendingFacets,
+  getTrendingItems,
+  WithRecommendMethods,
+} from '@algolia/recommend';
 import { Destroyable } from '@algolia/requester-common';
 import { createNodeHttpRequester } from '@algolia/requester-node-http';
 import { createUserAgent, Request, RequestOptions } from '@algolia/transporter';
@@ -346,6 +356,13 @@ export default function algoliasearch(
 
         return initPersonalization()(clientOptions);
       },
+      getRecommendations,
+      getFrequentlyBoughtTogether,
+      getLookingSimilar,
+      getRecommendedForYou,
+      getRelatedProducts,
+      getTrendingFacets,
+      getTrendingItems,
     },
   });
 }
@@ -697,6 +714,15 @@ export type SearchClient = BaseSearchClient & {
    * @deprecated Use `initPersonalization` instead.
    */
   readonly initRecommendation: (options?: InitPersonalizationOptions) => PersonalizationClient;
+  readonly getRecommendations: WithRecommendMethods<BaseSearchClient>['getRecommendations'];
+  readonly getFrequentlyBoughtTogether: WithRecommendMethods<
+    BaseSearchClient
+  >['getFrequentlyBoughtTogether'];
+  readonly getLookingSimilar: WithRecommendMethods<BaseSearchClient>['getLookingSimilar'];
+  readonly getRecommendedForYou: WithRecommendMethods<BaseSearchClient>['getRecommendedForYou'];
+  readonly getRelatedProducts: WithRecommendMethods<BaseSearchClient>['getRelatedProducts'];
+  readonly getTrendingFacets: WithRecommendMethods<BaseSearchClient>['getTrendingFacets'];
+  readonly getTrendingItems: WithRecommendMethods<BaseSearchClient>['getTrendingItems'];
 } & Destroyable;
 
 export * from '../types';


### PR DESCRIPTION
This PR adds methods from **algolia/recommend** methods into **algoliasearch**, allowing Algolia customers to perform both search and get recommendations with a single API client.

In detail:
- **algoliasearch/lite** only implements `getRecommendations()`
- **algoliasearch** (browser + node) implement all the currently available methods in the recommend package

[FX-2773](https://algolia.atlassian.net/browse/FX-2773)

[FX-2773]: https://algolia.atlassian.net/browse/FX-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ