### PR TITLE
fix(recommend): export recommend methods to use them in algoliasearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
           name: Build
           command: yarn build
       - run:
+          name: Test exports
+          command: yarn test:exports
+      - run:
           name: Test size
           command: yarn test:build-size
       - run:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:browser-locally": "yarn setup:browser && ./scripts/prepare-test-browser.sh && wdio ./wdio.local.conf.js",
     "test:build-declarations": "node --max-old-space-size=4096 scripts/test-build-declarations.js",
     "test:build-size": "bundlesize",
+    "test:exports": "lerna run test:exports",
     "test:lint": "eslint . --ext .js,.ts",
     "test:locally": "lerna clean --yes && yarn lint && yarn test:types && yarn test:unit",
     "test:types": "yarn tsc",

--- a/packages/algoliasearch/package.json
+++ b/packages/algoliasearch/package.json
@@ -24,6 +24,9 @@
     "lite.js",
     "lite.d.ts"
   ],
+  "scripts": {
+    "test:exports": "node --experimental-modules test/module/is-es-module.mjs && node test/module/is-cjs-module.cjs"
+  },
   "dependencies": {
     "@algolia/cache-browser-local-storage": "4.23.0",
     "@algolia/cache-common": "4.23.0",

--- a/packages/algoliasearch/test/module/is-cjs-module.cjs
+++ b/packages/algoliasearch/test/module/is-cjs-module.cjs
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-disable no-console */
+const algoliasearch = require('algoliasearch');
+const assert = require('assert');
+
+assert.ok(algoliasearch);
+assert.doesNotThrow(() => algoliasearch('..', '..'));
+
+console.log('algoliasearch is valid CJS');

--- a/packages/algoliasearch/test/module/is-es-module.mjs
+++ b/packages/algoliasearch/test/module/is-es-module.mjs
@@ -1,0 +1,8 @@
+/* eslint-disable no-console */
+import algoliasearch from 'algoliasearch';
+import assert from 'assert';
+
+assert.ok(algoliasearch);
+assert.doesNotThrow(() => algoliasearch('..', '..'));
+
+console.log('algoliasearch is valid ESM');

--- a/packages/recommend/src/builds/browser.ts
+++ b/packages/recommend/src/builds/browser.ts
@@ -68,4 +68,5 @@ recommend.version = version;
 
 export type RecommendClient = WithRecommendMethods<BaseRecommendClient>;
 
+export * from '../methods';
 export * from '../types';

--- a/packages/recommend/src/builds/node.ts
+++ b/packages/recommend/src/builds/node.ts
@@ -62,4 +62,5 @@ recommend.version = version;
 
 export type RecommendClient = WithRecommendMethods<BaseRecommendClient> & Destroyable;
 
+export * from '../methods';
 export * from '../types';


### PR DESCRIPTION
In 8087b282, we import methods from `@algolia/recommend` into `algoliasearch` to give direct access to recommendations from the search client.

The CJS bundle for `@algolia/recommend` did not export the methods, only the `recommend()` method to set up a recommend client. This caused an issue in the v4.23.0 release of `algoliasearch` as it basically imported undefined methods, which prevented the correct instantiation of the search client.

This PR reexports all methods to ensure they are present when imported by `algoliasearch`.

It also tests the built algoliasearch bundles, inspired by what we have [in InstantSearch](https://github.com/algolia/instantsearch/pull/5175).

Fixes #1511