### PR TITLE
fix(support): redirect to ticket link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Algolia <support@algolia.com>
+Copyright (c) Algolia <http://www.algolia.com/>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/transporter/src/__tests__/integration/with-hosts-cache-drivers.test.ts
+++ b/packages/transporter/src/__tests__/integration/with-hosts-cache-drivers.test.ts
@@ -63,7 +63,7 @@ describe('hosts cache integration with cache drivers', () => {
 
         const message =
           // eslint-disable-next-line max-len
-          'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.';
+          'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).';
 
         await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
           message,

--- a/packages/transporter/src/__tests__/integration/with-hosts-cache-drivers.test.ts
+++ b/packages/transporter/src/__tests__/integration/with-hosts-cache-drivers.test.ts
@@ -63,7 +63,7 @@ describe('hosts cache integration with cache drivers', () => {
 
         const message =
           // eslint-disable-next-line max-len
-          'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).';
+          'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .';
 
         await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
           message,

--- a/packages/transporter/src/__tests__/unit/stackTrace.test.ts
+++ b/packages/transporter/src/__tests__/unit/stackTrace.test.ts
@@ -90,7 +90,7 @@ describe('transporter stack trace serialization', () => {
     await expect(transporter.read(transporterRequest)).rejects.toEqual({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
       transporterStackTrace,
     });
 

--- a/packages/transporter/src/__tests__/unit/stackTrace.test.ts
+++ b/packages/transporter/src/__tests__/unit/stackTrace.test.ts
@@ -90,7 +90,7 @@ describe('transporter stack trace serialization', () => {
     await expect(transporter.read(transporterRequest)).rejects.toEqual({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .',
       transporterStackTrace,
     });
 

--- a/packages/transporter/src/__tests__/unit/timeouts.test.ts
+++ b/packages/transporter/src/__tests__/unit/timeouts.test.ts
@@ -86,7 +86,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .',
     });
 
     assertRequest({
@@ -111,7 +111,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .',
     });
 
     assertRequest({
@@ -142,7 +142,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .',
     });
 
     assertRequest({

--- a/packages/transporter/src/__tests__/unit/timeouts.test.ts
+++ b/packages/transporter/src/__tests__/unit/timeouts.test.ts
@@ -86,7 +86,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
     });
 
     assertRequest({

--- a/packages/transporter/src/__tests__/unit/timeouts.test.ts
+++ b/packages/transporter/src/__tests__/unit/timeouts.test.ts
@@ -111,7 +111,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
     });
 
     assertRequest({
@@ -142,7 +142,7 @@ describe('the timeouts selection', () => {
     await expect(transporter.read(transporterRequest)).rejects.toMatchObject({
       name: 'RetryError',
       message:
-        'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+        'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
     });
 
     assertRequest({

--- a/packages/transporter/src/errors/createRetryError.ts
+++ b/packages/transporter/src/errors/createRetryError.ts
@@ -4,7 +4,7 @@ export function createRetryError(transporterStackTrace: readonly StackFrame[]): 
   return {
     name: 'RetryError',
     message:
-      'Unreachable hosts - your application id may be incorrect. If the error persists, contact support@algolia.com.',
+      'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
     transporterStackTrace,
   };
 }

--- a/packages/transporter/src/errors/createRetryError.ts
+++ b/packages/transporter/src/errors/createRetryError.ts
@@ -4,7 +4,7 @@ export function createRetryError(transporterStackTrace: readonly StackFrame[]): 
   return {
     name: 'RetryError',
     message:
-      'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the [Algolia Support team](https://support.algolia.com/hc/en-us/requests/new).',
+      'Unreachable hosts - your application id may be incorrect. If the error persists, please reach out to the Algolia Support team: https://alg.li/support .',
     transporterStackTrace,
   };
 }


### PR DESCRIPTION
Hey team! 
The Support team is currently in a process of removing [support@algolia.com](mailto:support@algolia.com) email from all GitHub repos and updating it to link to the new ticket form. We kindly ask that you review the changes made removing references to [support@algolia.com](mailto:support@algolia.com). 
Thanks!