### PR TITLE
fix(types): add `serverTimeMS` to search response

### DIFF
--- a/packages/client-search/src/types/SearchResponse.ts
+++ b/packages/client-search/src/types/SearchResponse.ts
@@ -53,6 +53,11 @@ export type SearchResponse<TObject = {}> = {
   processingTimeMS: number;
 
   /**
+   * Time the server took to process the request, in milliseconds.
+   */
+  serverTimeMS?: number;
+
+  /**
    * Whether the nbHits is exhaustive (true) or approximate (false).
    *
    * An approximation is done when the query takes more than 50ms to be


### PR DESCRIPTION
users would like to leverage this field, documented here https://www.algolia.com/doc/api-reference/api-methods/search/#method-response-servertimems, see [CR-5848](https://algolia.atlassian.net/browse/CR-5848)

it is already provided on the `next` version

[CR-5848]: https://algolia.atlassian.net/browse/CR-5848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ