### PR TITLE
fix: add types to manifest exports

### DIFF
--- a/packages/algoliasearch/package.json
+++ b/packages/algoliasearch/package.json
@@ -16,13 +16,15 @@
         "import": "./dist/algoliasearch.esm.node.js",
         "module": "./dist/algoliasearch.esm.node.js",
         "require": "./dist/algoliasearch.cjs",
-        "default": "./dist/algoliasearch.cjs"
+        "default": "./dist/algoliasearch.cjs",
+        "types": "./dist/algoliasearch/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/algoliasearch.umd.js",
         "module": "./dist/algoliasearch.esm.browser.js",
         "import": "./dist/algoliasearch.esm.browser.js",
-        "default": "./dist/algoliasearch.umd.js"
+        "default": "./dist/algoliasearch.umd.js",
+        "types": "./dist/algoliasearch/builds/browser.d.ts"
       }
     },
     "./lite": {
@@ -31,13 +33,15 @@
         "import": "./dist/lite/lite.esm.node.js",
         "module": "./dist/lite/lite.esm.node.js",
         "require": "./dist/lite/lite.cjs",
-        "default": "./dist/lite/lite.cjs"
+        "default": "./dist/lite/lite.cjs",
+        "types": "./dist/lite/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/lite/lite.umd.js",
         "module": "./dist/lite/lite.esm.browser.js",
         "import": "./dist/lite/lite.esm.browser.js",
-        "default": "./dist/lite/lite.umd.js"
+        "default": "./dist/lite/lite.umd.js",
+        "types": "./dist/lite/builds/browser.d.ts"
       }
     }
   },

--- a/packages/client-abtesting/package.json
+++ b/packages/client-abtesting/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-abtesting.esm.node.js",
         "module": "./dist/client-abtesting.esm.node.js",
         "require": "./dist/client-abtesting.cjs",
-        "default": "./dist/client-abtesting.cjs"
+        "default": "./dist/client-abtesting.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-abtesting.umd.js",
         "module": "./dist/client-abtesting.esm.browser.js",
         "import": "./dist/client-abtesting.esm.browser.js",
-        "default": "./dist/client-abtesting.umd.js"
+        "default": "./dist/client-abtesting.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-analytics/package.json
+++ b/packages/client-analytics/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-analytics.esm.node.js",
         "module": "./dist/client-analytics.esm.node.js",
         "require": "./dist/client-analytics.cjs",
-        "default": "./dist/client-analytics.cjs"
+        "default": "./dist/client-analytics.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-analytics.umd.js",
         "module": "./dist/client-analytics.esm.browser.js",
         "import": "./dist/client-analytics.esm.browser.js",
-        "default": "./dist/client-analytics.umd.js"
+        "default": "./dist/client-analytics.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-insights/package.json
+++ b/packages/client-insights/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-insights.esm.node.js",
         "module": "./dist/client-insights.esm.node.js",
         "require": "./dist/client-insights.cjs",
-        "default": "./dist/client-insights.cjs"
+        "default": "./dist/client-insights.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-insights.umd.js",
         "module": "./dist/client-insights.esm.browser.js",
         "import": "./dist/client-insights.esm.browser.js",
-        "default": "./dist/client-insights.umd.js"
+        "default": "./dist/client-insights.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-personalization/package.json
+++ b/packages/client-personalization/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-personalization.esm.node.js",
         "module": "./dist/client-personalization.esm.node.js",
         "require": "./dist/client-personalization.cjs",
-        "default": "./dist/client-personalization.cjs"
+        "default": "./dist/client-personalization.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-personalization.umd.js",
         "module": "./dist/client-personalization.esm.browser.js",
         "import": "./dist/client-personalization.esm.browser.js",
-        "default": "./dist/client-personalization.umd.js"
+        "default": "./dist/client-personalization.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-query-suggestions/package.json
+++ b/packages/client-query-suggestions/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-query-suggestions.esm.node.js",
         "module": "./dist/client-query-suggestions.esm.node.js",
         "require": "./dist/client-query-suggestions.cjs",
-        "default": "./dist/client-query-suggestions.cjs"
+        "default": "./dist/client-query-suggestions.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-query-suggestions.umd.js",
         "module": "./dist/client-query-suggestions.esm.browser.js",
         "import": "./dist/client-query-suggestions.esm.browser.js",
-        "default": "./dist/client-query-suggestions.umd.js"
+        "default": "./dist/client-query-suggestions.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-search/package.json
+++ b/packages/client-search/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-search.esm.node.js",
         "module": "./dist/client-search.esm.node.js",
         "require": "./dist/client-search.cjs",
-        "default": "./dist/client-search.cjs"
+        "default": "./dist/client-search.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-search.umd.js",
         "module": "./dist/client-search.esm.browser.js",
         "import": "./dist/client-search.esm.browser.js",
-        "default": "./dist/client-search.umd.js"
+        "default": "./dist/client-search.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/client-usage/package.json
+++ b/packages/client-usage/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/client-usage.esm.node.js",
         "module": "./dist/client-usage.esm.node.js",
         "require": "./dist/client-usage.cjs",
-        "default": "./dist/client-usage.cjs"
+        "default": "./dist/client-usage.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/client-usage.umd.js",
         "module": "./dist/client-usage.esm.browser.js",
         "import": "./dist/client-usage.esm.browser.js",
-        "default": "./dist/client-usage.umd.js"
+        "default": "./dist/client-usage.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/ingestion.esm.node.js",
         "module": "./dist/ingestion.esm.node.js",
         "require": "./dist/ingestion.cjs",
-        "default": "./dist/ingestion.cjs"
+        "default": "./dist/ingestion.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/ingestion.umd.js",
         "module": "./dist/ingestion.esm.browser.js",
         "import": "./dist/ingestion.esm.browser.js",
-        "default": "./dist/ingestion.umd.js"
+        "default": "./dist/ingestion.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/monitoring.esm.node.js",
         "module": "./dist/monitoring.esm.node.js",
         "require": "./dist/monitoring.cjs",
-        "default": "./dist/monitoring.cjs"
+        "default": "./dist/monitoring.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/monitoring.umd.js",
         "module": "./dist/monitoring.esm.browser.js",
         "import": "./dist/monitoring.esm.browser.js",
-        "default": "./dist/monitoring.umd.js"
+        "default": "./dist/monitoring.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",

--- a/packages/recommend/package.json
+++ b/packages/recommend/package.json
@@ -15,13 +15,15 @@
         "import": "./dist/recommend.esm.node.js",
         "module": "./dist/recommend.esm.node.js",
         "require": "./dist/recommend.cjs",
-        "default": "./dist/recommend.cjs"
+        "default": "./dist/recommend.cjs",
+        "types": "./dist/builds/node.d.ts"
       },
       "default": {
         "umd": "./dist/recommend.umd.js",
         "module": "./dist/recommend.esm.browser.js",
         "import": "./dist/recommend.esm.browser.js",
-        "default": "./dist/recommend.umd.js"
+        "default": "./dist/recommend.umd.js",
+        "types": "./dist/builds/browser.d.ts"
       }
     },
     "./src/*": "./src/*.ts",


### PR DESCRIPTION
Apologies in advance if I have missed something.

fixes: #1540 

Type exports were missing from the manifest. I have verified locally that the types now work, however have noticed that the inferred return type from algoliasearch is still failing, possibly due to the use of `*.ts` files from the other packages. This may require changes to the build config. 

I can create a minimum repo to help with testing in the morning if need be. 