### PR TITLE
fix(docs): package.json `homepage` field

### DIFF
--- a/packages/algoliasearch/package.json
+++ b/packages/algoliasearch/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/algoliasearch#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/algoliasearch#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-analytics/package.json
+++ b/packages/client-analytics/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-analytics#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-analytics#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-composition/package.json
+++ b/packages/client-composition/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-composition#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-composition#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-insights/package.json
+++ b/packages/client-insights/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-insights#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-insights#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-personalization/package.json
+++ b/packages/client-personalization/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-personalization#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-personalization#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-query-suggestions/package.json
+++ b/packages/client-query-suggestions/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-query-suggestions#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-query-suggestions#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/client-search/package.json
+++ b/packages/client-search/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/client-search#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/client-search#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/composition/package.json
+++ b/packages/composition/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/composition#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/composition#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/ingestion#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/ingestion#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/monitoring#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/monitoring#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",

--- a/packages/recommend/package.json
+++ b/packages/recommend/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
   },
-  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/packages/recommend#readme",
+  "homepage": "https://github.com/algolia/algoliasearch-client-javascript/tree/main/packages/recommend#readme",
   "type": "module",
   "license": "MIT",
   "author": "Algolia",


### PR DESCRIPTION

The links to packages deployed on npm are incorrect.
when I click the current homepage link, page 404 is displayed.
So I modified the `homepage` field of `package.json`

---

https://www.npmjs.com/package/algoliasearch
https://github.com/algolia/algoliasearch-client-javascript/packages/algoliasearch#readme
<img width="894" alt="스크린샷 2025-02-02 오후 6 23 04" src="https://github.com/user-attachments/assets/94ef164b-307c-43b5-88e6-7cda0fbd91e3" />

