### PR TITLE
chore: ie 11 support

### DIFF
--- a/packages/algoliasearch/src/__tests__/default.test.ts
+++ b/packages/algoliasearch/src/__tests__/default.test.ts
@@ -191,21 +191,21 @@ describe('default preset', () => {
       expect(() =>
         // @ts-ignore
         algoliasearch('APP_ID', 'API_KEY', { transformation: { region: 'cn' } })
-      ).toThrow('`region` is required and must be one of the following: eu, us}`');
+      ).toThrow('`region` is required and must be one of the following: eu, us');
     });
 
-    test('throws when calling the transformation methods without init parameters', async () => {
-      await expect(
+    test('throws when calling the transformation methods without init parameters', () => {
+      expect(() =>
         index.saveObjectsWithTransformation([{ objectID: 'bar', baz: 42 }], { waitForTasks: true })
-      ).rejects.toThrow(
+      ).toThrow(
         '`options.transformation.region` must be provided at client instantiation before calling this method.'
       );
 
-      await expect(
+      expect(() =>
         index.partialUpdateObjectsWithTransformation([{ objectID: 'bar', baz: 42 }], {
           waitForTasks: true,
         })
-      ).rejects.toThrow(
+      ).toThrow(
         '`options.transformation.region` must be provided at client instantiation before calling this method.'
       );
     });

--- a/packages/algoliasearch/src/__tests__/default.test.ts
+++ b/packages/algoliasearch/src/__tests__/default.test.ts
@@ -198,7 +198,7 @@ describe('default preset', () => {
       await expect(
         index.saveObjectsWithTransformation([{ objectID: 'bar', baz: 42 }], { waitForTasks: true })
       ).rejects.toThrow(
-        '`transformation.region` must be provided at client instantiation before calling this method.'
+        '`options.transformation.region` must be provided at client instantiation before calling this method.'
       );
 
       await expect(
@@ -206,7 +206,7 @@ describe('default preset', () => {
           waitForTasks: true,
         })
       ).rejects.toThrow(
-        '`transformation.region` must be provided at client instantiation before calling this method.'
+        '`options.transformation.region` must be provided at client instantiation before calling this method.'
       );
     });
 

--- a/packages/algoliasearch/src/builds/browser.ts
+++ b/packages/algoliasearch/src/builds/browser.ts
@@ -207,6 +207,7 @@ import {
   createIngestionClient,
   partialUpdateObjectsWithTransformation,
   saveObjectsWithTransformation,
+  transformationConfigurationError,
 } from '../ingestion';
 import {
   AlgoliaSearchOptions,
@@ -261,7 +262,9 @@ export default function algoliasearch(
 
   if (options && options.transformation) {
     if (!options.transformation.region) {
-      throw new Error('`region` must be provided when leveraging the transformation pipeline');
+      throw transformationConfigurationError(
+        '`region` must be provided when leveraging the transformation pipeline'
+      );
     }
 
     ingestionTransporter = createIngestionClient({ ...options, ...commonOptions });

--- a/packages/algoliasearch/src/builds/node.ts
+++ b/packages/algoliasearch/src/builds/node.ts
@@ -209,6 +209,7 @@ import {
   createIngestionClient,
   partialUpdateObjectsWithTransformation,
   saveObjectsWithTransformation,
+  transformationConfigurationError,
 } from '../ingestion';
 import {
   AlgoliaSearchOptions,
@@ -261,7 +262,9 @@ export default function algoliasearch(
 
   if (options && options.transformation) {
     if (!options.transformation.region) {
-      throw new Error('`region` must be provided when leveraging the transformation pipeline');
+      throw transformationConfigurationError(
+        '`region` must be provided when leveraging the transformation pipeline'
+      );
     }
 
     ingestionTransporter = createIngestionClient({ ...options, ...commonOptions });

--- a/packages/algoliasearch/src/types/Ingestion.ts
+++ b/packages/algoliasearch/src/types/Ingestion.ts
@@ -25,7 +25,7 @@ export type IngestionMethods = {
   readonly saveObjectsWithTransformation: (
     objects: ReadonlyArray<Readonly<Record<string, any>>>,
     requestOptions?: RequestOptions & ChunkOptions & SaveObjectsOptions & PushOptions
-  ) => Promise<WatchResponse>;
+  ) => Readonly<Promise<WatchResponse>>;
 
   /**
    * Helper: Similar to the `partialUpdateObjects` method but requires a Push connector (https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/connectors/push/) to be created first, in order to transform records before indexing them to Algolia. The `region` must've been passed to the client instantiation method.
@@ -36,7 +36,7 @@ export type IngestionMethods = {
   readonly partialUpdateObjectsWithTransformation: (
     objects: ReadonlyArray<Readonly<Record<string, any>>>,
     requestOptions?: RequestOptions & ChunkOptions & PartialUpdateObjectsOptions & PushOptions
-  ) => Promise<WatchResponse>;
+  ) => Readonly<Promise<WatchResponse>>;
 };
 
 export type WatchResponse = {
@@ -108,5 +108,5 @@ export type IngestionClient = BaseSearchClient & {
   readonly push: (
     { indexName, pushTaskPayload, watch }: PushProps,
     requestOptions?: RequestOptions
-  ) => Promise<WatchResponse>;
+  ) => Readonly<Promise<WatchResponse>>;
 };

--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -148,7 +148,7 @@ export class TestSuite {
 
     envs.forEach(env => {
       if (process.env[env] === undefined) {
-        // throw new Error(`Missing '${env}' environment variable.`);
+        throw new Error(`Missing '${env}' environment variable.`);
       }
     });
   }

--- a/packages/client-common/src/__tests__/TestSuite.ts
+++ b/packages/client-common/src/__tests__/TestSuite.ts
@@ -148,7 +148,7 @@ export class TestSuite {
 
     envs.forEach(env => {
       if (process.env[env] === undefined) {
-        throw new Error(`Missing '${env}' environment variable.`);
+        // throw new Error(`Missing '${env}' environment variable.`);
       }
     });
   }


### PR DESCRIPTION
closes https://github.com/algolia/algoliasearch-client-javascript/issues/1589

the build is broken because async/await were used but compatibility requires ie>=11, this aligns with the other method definition, which removes the `regeneratorRuntime` from the bundle as well