### PR TITLE
fix: always delete temporary index in replaceAllObjects

### DIFF
--- a/packages/client-search/src/methods/index/replaceAllObjects.ts
+++ b/packages/client-search/src/methods/index/replaceAllObjects.ts
@@ -103,13 +103,19 @@ export const replaceAllObjects = (base: SearchIndex) => {
         };
       })
       .catch(error => {
-        deleteIndex({
+        // Clean up temporary index if there's an error
+        // eslint-disable-next-line promise/no-nesting
+        return deleteIndex({
           appId: base.appId,
           transporter: base.transporter,
           indexName: temporaryIndexName,
-        })().wait();
-
-        throw error;
+        })()
+          .catch(() => {
+            // Ignore delete errors
+          })
+          .then(() => {
+            throw error;
+          });
       });
 
     return createWaitablePromise(result, (_, waitRequestOptions) => {


### PR DESCRIPTION
If there is an error during the `saveObjects` or `move` in `replaceAllObjects`, it will leave behind the temporary index, and count in the index limit of the app.

Add a clean up step that will be delete the index in case of failure.