### PR TITLE
fix: handle response stream error in createHttpRequester

### DIFF
--- a/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
+++ b/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
@@ -278,4 +278,18 @@ describe('error handling', (): void => {
     expect(response.content).toBe('This is a general error');
     expect(response.isTimedOut).toBe(false);
   });
+
+
+  test('resolves response stream errors', async () => {
+    nock(testQueryBaseUrl, { reqheaders: headers })
+        .post('/foo')
+        .query(testQueryHeader)
+        .replyWithError('This is a response stream error');
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBe('This is a response stream error');
+    expect(response.isTimedOut).toBe(false);
+  });
 });

--- a/packages/requester-node-http/src/createHttpRequester.ts
+++ b/packages/requester-node-http/src/createHttpRequester.ts
@@ -74,6 +74,11 @@ export function createHttpRequester({
             isTimedOut: false,
           });
         });
+        response.on('error', (error) => {
+          clearTimeout(connectTimeout as NodeJS.Timeout);
+          clearTimeout(responseTimeout as NodeJS.Timeout);
+          resolve({ status: 0, content: error.message, isTimedOut: false });
+        });
       });
 
       const createTimeout = (timeout: number, content: string): NodeJS.Timeout => {


### PR DESCRIPTION
## Summary

The response stream in `createHttpRequester` had no `error` event handler.

According to the Node.js stream documentation, if an `error` event handler is not added, the error will be thrown as an unhandled exception.

ref: https://nodejs.org/api/stream.html#event-error

## Problem

When a network error occurs during response streaming:
- `response.on('error')` was not handled
- `connectTimeout` and `responseTimeout` were never cleared
- Node.js would throw an unhandled exception

## What I changed

Added `response.on('error')` to properly clear timeouts and resolve
the promise on response stream errors.

### Test Results
<img width="1284" height="560" alt="スクリーンショット 2026-03-20 14 28 53" src="https://github.com/user-attachments/assets/5f17642f-f312-44e9-afcb-67acf6c838de" />
